### PR TITLE
Add tank armor and projectile simulation scripts

### DIFF
--- a/CodexTest/Assets/Scripts.meta
+++ b/CodexTest/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9a2cdf2e56ee484abfe17aa0acdee345
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/ArmorProfile.cs
+++ b/CodexTest/Assets/Scripts/ArmorProfile.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+[CreateAssetMenu(fileName = "TankArmor", menuName = "Ballistics/ArmorProfile")]
+public class ArmorProfile : ScriptableObject
+{
+    [System.Serializable]
+    public struct ArmorPlate
+    {
+        public string id;        // Identifier, must match collider name
+        public float thickness;  // millimetres
+        public float slope;      // degrees from vertical
+        public float hardness;   // optional material modifier
+    }
+
+    public List<ArmorPlate> plates = new List<ArmorPlate>();
+
+    /// <summary>Find plate data by id.</summary>
+    public bool TryGetPlate(string id, out ArmorPlate plate)
+    {
+        int index = plates.FindIndex(p => p.id == id);
+        if (index >= 0)
+        {
+            plate = plates[index];
+            return true;
+        }
+        plate = default;
+        return false;
+    }
+}

--- a/CodexTest/Assets/Scripts/ArmorProfile.cs.meta
+++ b/CodexTest/Assets/Scripts/ArmorProfile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a889f7435dc34f8a9a2e3419953a7276
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/BallisticCalculator.cs
+++ b/CodexTest/Assets/Scripts/BallisticCalculator.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+
+public static class BallisticCalculator
+{
+    public enum HitResult { Penetration, Ricochet, Stopped }
+
+    public struct HitData
+    {
+        public HitResult result;
+        public float impactAngle;      // degrees
+        public float effectiveThickness;
+        public float penetrationRemaining;
+    }
+
+    public static HitData EvaluateHit(
+        ProjectileData projectile,
+        ArmorProfile.ArmorPlate plate,
+        float distance,
+        Vector3 shotDir,
+        Vector3 plateNormal)
+    {
+        float velocity = projectile.GetVelocityAtDistance(distance);
+        float penetration = projectile.GetPenetrationAtDistance(distance);
+        float angle = Vector3.Angle(-shotDir.normalized, plateNormal.normalized);
+        float effectiveThickness = plate.thickness / Mathf.Cos(angle * Mathf.Deg2Rad);
+
+        var hit = new HitData
+        {
+            impactAngle = angle,
+            effectiveThickness = effectiveThickness,
+            penetrationRemaining = penetration - effectiveThickness
+        };
+
+        if (angle > projectile.maxRicochetAngle)
+        {
+            hit.result = HitResult.Ricochet;
+        }
+        else if (penetration >= effectiveThickness)
+        {
+            hit.result = HitResult.Penetration;
+        }
+        else
+        {
+            hit.result = HitResult.Stopped;
+        }
+        return hit;
+    }
+}

--- a/CodexTest/Assets/Scripts/BallisticCalculator.cs.meta
+++ b/CodexTest/Assets/Scripts/BallisticCalculator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 19a562a505c444d7afcbf9ee782f3c83
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/ProjectileData.cs
+++ b/CodexTest/Assets/Scripts/ProjectileData.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "Projectile", menuName = "Ballistics/Projectile")]
+public class ProjectileData : ScriptableObject
+{
+    [Header("Basic Specs")]
+    public string projectileName;
+    public float caliber;        // mm
+    public float mass;           // kg
+    public float muzzleVelocity; // m/s
+
+    [Header("Penetration")]
+    public AnimationCurve penetrationByDistance; // distance (m) -> penetration (mm)
+    public float maxRicochetAngle = 70f; // degrees
+
+    /// <summary>Simple linear velocity drop-off.</summary>
+    public float GetVelocityAtDistance(float distance)
+    {
+        float drop = distance * 0.1f;
+        return Mathf.Max(0f, muzzleVelocity - drop);
+    }
+
+    /// <summary>Lookup penetration value from curve.</summary>
+    public float GetPenetrationAtDistance(float distance)
+    {
+        return penetrationByDistance.Evaluate(distance);
+    }
+}

--- a/CodexTest/Assets/Scripts/ProjectileData.cs.meta
+++ b/CodexTest/Assets/Scripts/ProjectileData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 954cfd185c054756b9aac035e8a8af99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/ShotSimulator.cs
+++ b/CodexTest/Assets/Scripts/ShotSimulator.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+using UnityEngine.Events;
+
+public class ShotSimulator : MonoBehaviour
+{
+    [Header("References")]
+    public Camera mainCam;
+    public ArmorProfile tankArmor;
+    public ProjectileData[] projectiles;
+
+    [Header("Events")]
+    public UnityEvent<string> onLog;
+
+    private int currentProjectileIndex;
+
+    void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Alpha1)) currentProjectileIndex = 0;
+        if (Input.GetKeyDown(KeyCode.Alpha2)) currentProjectileIndex = 1;
+        if (Input.GetKeyDown(KeyCode.Alpha3)) currentProjectileIndex = 2;
+
+        if (Input.GetMouseButtonDown(0))
+        {
+            Ray ray = mainCam.ScreenPointToRay(Input.mousePosition);
+            if (Physics.Raycast(ray, out RaycastHit hit))
+                ProcessHit(ray, hit);
+        }
+    }
+
+    void ProcessHit(Ray ray, RaycastHit hit)
+    {
+        if (projectiles.Length == 0)
+            return;
+
+        ProjectileData proj = projectiles[Mathf.Clamp(currentProjectileIndex, 0, projectiles.Length - 1)];
+        string plateId = hit.collider.gameObject.name;
+
+        if (!tankArmor.TryGetPlate(plateId, out var plate))
+        {
+            onLog.Invoke($"No armor data for {plateId}");
+            return;
+        }
+
+        var result = BallisticCalculator.EvaluateHit(
+            proj,
+            plate,
+            hit.distance,
+            ray.direction,
+            hit.normal);
+
+        onLog.Invoke(
+            $"{proj.projectileName} vs {plate.id} -> {result.result} | " +
+            $"Angle: {result.impactAngle:F1}° | EffThk: {result.effectiveThickness:F1}mm | " +
+            $"PenLeft: {result.penetrationRemaining:F1}mm");
+    }
+}

--- a/CodexTest/Assets/Scripts/ShotSimulator.cs.meta
+++ b/CodexTest/Assets/Scripts/ShotSimulator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 82a2c8bd280c4f0b8b6b183dc11356c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add projectile data ScriptableObject with penetration curves
- add tank armor profile ScriptableObject and hit evaluation logic
- implement ballistic calculator and interactive shot simulator

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894de0b06d48321ab79890a7f25ea07