### PR TITLE
Add drag selection and navigation package instructions

### DIFF
--- a/CodexTest/Assets/Scripts/Camera.meta
+++ b/CodexTest/Assets/Scripts/Camera.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 585f47c42a574099b0b1019a03288226
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/Camera/RTSCameraController.cs
+++ b/CodexTest/Assets/Scripts/Camera/RTSCameraController.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace RTS.CameraSystem
+{
+    /// <summary>
+    /// Basic top-down RTS camera with pan, rotate and zoom controls.
+    /// </summary>
+    public class RTSCameraController : MonoBehaviour
+    {
+        public float moveSpeed = 10f;
+        public float rotateSpeed = 100f;
+        public float zoomSpeed = 100f;
+        public float minZoom = 10f;
+        public float maxZoom = 100f;
+
+        private Camera _camera;
+
+        private void Awake()
+        {
+            _camera = GetComponentInChildren<Camera>();
+            if (_camera == null)
+                _camera = Camera.main;
+        }
+
+        private void Update()
+        {
+            var keyboard = Keyboard.current;
+            var mouse = Mouse.current;
+            if (keyboard == null || mouse == null)
+                return;
+
+            Vector3 direction = Vector3.zero;
+            if (keyboard.wKey.isPressed) direction += Vector3.forward;
+            if (keyboard.sKey.isPressed) direction += Vector3.back;
+            if (keyboard.aKey.isPressed) direction += Vector3.left;
+            if (keyboard.dKey.isPressed) direction += Vector3.right;
+            transform.Translate(direction * moveSpeed * Time.deltaTime, Space.World);
+
+            if (mouse.middleButton.isPressed)
+            {
+                Vector2 delta = mouse.delta.ReadValue();
+                transform.Rotate(Vector3.up, delta.x * rotateSpeed * Time.deltaTime, Space.World);
+            }
+
+            if (_camera != null)
+            {
+                float scroll = mouse.scroll.ReadValue().y;
+                if (Mathf.Abs(scroll) > 0.01f)
+                {
+                    Vector3 pos = _camera.transform.localPosition;
+                    pos.y = Mathf.Clamp(pos.y - scroll * zoomSpeed * Time.deltaTime, minZoom, maxZoom);
+                    _camera.transform.localPosition = pos;
+                }
+            }
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Camera/RTSCameraController.cs.meta
+++ b/CodexTest/Assets/Scripts/Camera/RTSCameraController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3027beb410144420bbceaeb943c7e29d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/Infantry.meta
+++ b/CodexTest/Assets/Scripts/Infantry.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 024ba05f145b4def9be395117babf2ba
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/Infantry/Components.meta
+++ b/CodexTest/Assets/Scripts/Infantry/Components.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c1183aa0df7a4e7fb1e79f0d2b95b3ce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/Infantry/Components/InfantryTag.cs
+++ b/CodexTest/Assets/Scripts/Infantry/Components/InfantryTag.cs
@@ -1,0 +1,7 @@
+using Unity.Entities;
+
+namespace RTS.Infantry
+{
+    /// <summary>Marks an entity as an infantry unit.</summary>
+    public struct InfantryTag : IComponentData { }
+}

--- a/CodexTest/Assets/Scripts/Infantry/Components/InfantryTag.cs.meta
+++ b/CodexTest/Assets/Scripts/Infantry/Components/InfantryTag.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ab29af08ead3441eaef456402efd06d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/Infantry/Components/MoveTarget.cs
+++ b/CodexTest/Assets/Scripts/Infantry/Components/MoveTarget.cs
@@ -1,0 +1,11 @@
+using Unity.Entities;
+using Unity.Mathematics;
+
+namespace RTS.Infantry
+{
+    /// <summary>Desired destination for a unit.</summary>
+    public struct MoveTarget : IComponentData
+    {
+        public float3 Position;
+    }
+}

--- a/CodexTest/Assets/Scripts/Infantry/Components/MoveTarget.cs.meta
+++ b/CodexTest/Assets/Scripts/Infantry/Components/MoveTarget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d74feb0eaead42b685c70478b2509d63
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/Infantry/Components/NavAgent.cs
+++ b/CodexTest/Assets/Scripts/Infantry/Components/NavAgent.cs
@@ -1,0 +1,11 @@
+using Unity.Entities;
+using UnityEngine.AI;
+
+namespace RTS.Infantry
+{
+    /// <summary>Managed component wrapping a NavMeshAgent reference.</summary>
+    public class NavAgent : IComponentData
+    {
+        public NavMeshAgent Agent;
+    }
+}

--- a/CodexTest/Assets/Scripts/Infantry/Components/NavAgent.cs.meta
+++ b/CodexTest/Assets/Scripts/Infantry/Components/NavAgent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 08957591dc104ed9b197529b08a62b41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/Infantry/Components/SelectedTag.cs
+++ b/CodexTest/Assets/Scripts/Infantry/Components/SelectedTag.cs
@@ -1,0 +1,7 @@
+using Unity.Entities;
+
+namespace RTS.Infantry
+{
+    /// <summary>Indicates that the unit is currently selected.</summary>
+    public struct SelectedTag : IComponentData, IEnableableComponent { }
+}

--- a/CodexTest/Assets/Scripts/Infantry/Components/SelectedTag.cs.meta
+++ b/CodexTest/Assets/Scripts/Infantry/Components/SelectedTag.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68e2ea04125b4876a7d3218dfaa45d6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/Infantry/EntityReference.cs
+++ b/CodexTest/Assets/Scripts/Infantry/EntityReference.cs
@@ -1,0 +1,13 @@
+using Unity.Entities;
+using UnityEngine;
+
+namespace RTS.Infantry
+{
+    /// <summary>
+    /// Helper MonoBehaviour holding an Entity created at conversion time.
+    /// </summary>
+    public class EntityReference : MonoBehaviour
+    {
+        public Entity Entity;
+    }
+}

--- a/CodexTest/Assets/Scripts/Infantry/EntityReference.cs.meta
+++ b/CodexTest/Assets/Scripts/Infantry/EntityReference.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f110fe87d688411ab4b3614cac49bc5b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/Infantry/Systems.meta
+++ b/CodexTest/Assets/Scripts/Infantry/Systems.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e1fbbfec0af9401e9cbc6bbcf5455dca
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/Infantry/Systems/MoveCommandSystem.cs
+++ b/CodexTest/Assets/Scripts/Infantry/Systems/MoveCommandSystem.cs
@@ -1,0 +1,48 @@
+using Unity.Entities;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace RTS.Infantry
+{
+    /// <summary>
+    /// Issues move orders to selected units based on right mouse clicks.
+    /// </summary>
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial class MoveCommandSystem : SystemBase
+    {
+        private Camera _camera;
+
+        protected override void OnCreate()
+        {
+            _camera = Camera.main;
+        }
+
+        protected override void OnUpdate()
+        {
+            var mouse = Mouse.current;
+            if (mouse == null || _camera == null || !mouse.rightButton.wasPressedThisFrame)
+                return;
+
+            var ray = _camera.ScreenPointToRay(mouse.position.ReadValue());
+            if (Physics.Raycast(ray, out var hit))
+            {
+                var destination = hit.point;
+
+                Entities
+                    .WithAll<SelectedTag>()
+                    .WithStructuralChanges()
+                    .ForEach((Entity entity) =>
+                    {
+                        if (EntityManager.HasComponent<MoveTarget>(entity))
+                        {
+                            EntityManager.SetComponentData(entity, new MoveTarget { Position = destination });
+                        }
+                        else
+                        {
+                            EntityManager.AddComponentData(entity, new MoveTarget { Position = destination });
+                        }
+                    }).Run();
+            }
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Infantry/Systems/MoveCommandSystem.cs.meta
+++ b/CodexTest/Assets/Scripts/Infantry/Systems/MoveCommandSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2097b602df145b2a21e66395a10a972
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/Infantry/Systems/NavMeshMovementSystem.cs
+++ b/CodexTest/Assets/Scripts/Infantry/Systems/NavMeshMovementSystem.cs
@@ -1,0 +1,30 @@
+using Unity.Entities;
+using UnityEngine;
+
+namespace RTS.Infantry
+{
+    /// <summary>
+    /// Drives NavMeshAgents toward their MoveTarget positions.
+    /// </summary>
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial class NavMeshMovementSystem : SystemBase
+    {
+        protected override void OnUpdate()
+        {
+            Entities
+                .WithStructuralChanges()
+                .ForEach((Entity entity, NavAgent agent, in MoveTarget target) =>
+                {
+                    if (agent.Agent == null)
+                        return;
+
+                    agent.Agent.SetDestination(target.Position);
+
+                    if (!agent.Agent.pathPending && agent.Agent.remainingDistance <= agent.Agent.stoppingDistance)
+                    {
+                        EntityManager.RemoveComponent<MoveTarget>(entity);
+                    }
+                }).Run();
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Infantry/Systems/NavMeshMovementSystem.cs.meta
+++ b/CodexTest/Assets/Scripts/Infantry/Systems/NavMeshMovementSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: df93ef469c3e403a8ad930bf9515c482
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/Infantry/Systems/SelectionSystem.cs
+++ b/CodexTest/Assets/Scripts/Infantry/Systems/SelectionSystem.cs
@@ -1,0 +1,111 @@
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace RTS.Infantry
+{
+    /// <summary>
+    /// Handles single and drag selection of infantry units.
+    /// </summary>
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial class SelectionSystem : SystemBase
+    {
+        private Camera _camera;
+        private bool _isDragging;
+        private Vector2 _dragStart;
+
+        protected override void OnCreate()
+        {
+            _camera = Camera.main;
+        }
+
+        protected override void OnUpdate()
+        {
+            var mouse = Mouse.current;
+            if (mouse == null || _camera == null) return;
+
+            if (mouse.leftButton.wasPressedThisFrame)
+            {
+                _isDragging = true;
+                _dragStart = mouse.position.ReadValue();
+            }
+
+            if (mouse.leftButton.wasReleasedThisFrame && _isDragging)
+            {
+                var end = mouse.position.ReadValue();
+                if (Vector2.Distance(_dragStart, end) < 4f)
+                {
+                    SingleSelect(end);
+                }
+                else
+                {
+                    DragSelect(_dragStart, end);
+                }
+
+                _isDragging = false;
+            }
+        }
+
+        private void ClearSelection()
+        {
+            Entities
+                .WithAll<SelectedTag>()
+                .WithStructuralChanges()
+                .ForEach((Entity entity) =>
+                {
+                    EntityManager.RemoveComponent<SelectedTag>(entity);
+                }).Run();
+        }
+
+        private void SingleSelect(Vector2 screenPos)
+        {
+            var keyboard = Keyboard.current;
+            bool additive = keyboard != null && keyboard.shiftKey.isPressed;
+            if (!additive)
+                ClearSelection();
+
+            var ray = _camera.ScreenPointToRay(screenPos);
+            if (Physics.Raycast(ray, out var hit))
+            {
+                if (hit.transform.TryGetComponent<EntityReference>(out var reference))
+                {
+                    var entity = reference.Entity;
+                    if (EntityManager.Exists(entity) && EntityManager.HasComponent<InfantryTag>(entity))
+                    {
+                        if (!EntityManager.HasComponent<SelectedTag>(entity))
+                            EntityManager.AddComponent<SelectedTag>(entity);
+                    }
+                }
+            }
+        }
+
+        private void DragSelect(Vector2 start, Vector2 end)
+        {
+            var keyboard = Keyboard.current;
+            bool additive = keyboard != null && keyboard.shiftKey.isPressed;
+            if (!additive)
+                ClearSelection();
+
+            var rect = Rect.MinMaxRect(
+                math.min(start.x, end.x),
+                math.min(start.y, end.y),
+                math.max(start.x, end.x),
+                math.max(start.y, end.y));
+
+            Entities
+                .WithAll<InfantryTag>()
+                .WithStructuralChanges()
+                .ForEach((Entity entity, in LocalToWorld transform) =>
+                {
+                    Vector3 screen = _camera.WorldToScreenPoint(transform.Position);
+                    if (rect.Contains((Vector2)screen))
+                    {
+                        if (!EntityManager.HasComponent<SelectedTag>(entity))
+                            EntityManager.AddComponent<SelectedTag>(entity);
+                    }
+                }).Run();
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Infantry/Systems/SelectionSystem.cs.meta
+++ b/CodexTest/Assets/Scripts/Infantry/Systems/SelectionSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 605294955baa448f9fd5b74154debc94
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Packages/manifest.json
+++ b/CodexTest/Packages/manifest.json
@@ -2,6 +2,9 @@
   "dependencies": {
     "com.unity.collab-proxy": "2.8.2",
     "com.unity.feature.development": "1.0.1",
+    "com.unity.entities": "1.0.16",
+    "com.unity.inputsystem": "1.7.0",
+    "com.unity.ai.navigation": "1.1.3",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.7.6",
     "com.unity.ugui": "1.0.0",

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # codex-test
+
+## Setup
+This Unity 2022.3 project relies on packages that are not included by default.
+Add them via the Package Manager or ensure `Packages/manifest.json` lists:
+
+- `com.unity.entities` – DOTS Entities 1.0 runtime
+- `com.unity.inputsystem` – new Input System used by the samples
+- `com.unity.ai.navigation` – provides the `NavMeshSurface` component
+
+After installing **AI Navigation**, add a `NavMeshSurface` to a GameObject and bake
+the NavMesh to enable infantry movement.


### PR DESCRIPTION
## Summary
- implement marquee selection with shift-additive selection
- add Entities, Input System, and AI Navigation packages and document NavMeshSurface setup

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894f92ef2948321a04b2a273e47cd61