### PR TITLE
feat: add infantry authoring

### DIFF
--- a/CodexTest/Assets/Scripts/Infantry/InfantryAuthoring.cs
+++ b/CodexTest/Assets/Scripts/Infantry/InfantryAuthoring.cs
@@ -1,0 +1,40 @@
+using Unity.Entities;
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace RTS.Infantry
+{
+    /// <summary>
+    /// Converts a GameObject with a NavMeshAgent into an infantry entity.
+    /// Adds the <see cref="InfantryTag"/> and <see cref="NavAgent"/> components
+    /// and stores the created entity on an attached <see cref="EntityReference"/>.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(NavMeshAgent))]
+    public class InfantryAuthoring : MonoBehaviour
+    {
+        class Baker : Baker<InfantryAuthoring>
+        {
+            public override void Bake(InfantryAuthoring authoring)
+            {
+                var entity = GetEntity(TransformUsageFlags.Dynamic);
+
+                // Tag as infantry for system queries
+                AddComponent<InfantryTag>(entity);
+
+                // Wrap the NavMeshAgent in a managed component
+                var agent = authoring.GetComponent<NavMeshAgent>();
+                if (agent != null)
+                {
+                    AddComponentObject(entity, new NavAgent { Agent = agent });
+                }
+
+                // Cache the entity on the reference MonoBehaviour if present
+                if (authoring.TryGetComponent<EntityReference>(out var reference))
+                {
+                    reference.Entity = entity;
+                }
+            }
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Infantry/InfantryAuthoring.cs.meta
+++ b/CodexTest/Assets/Scripts/Infantry/InfantryAuthoring.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1819d3fdc0f24954ad63eede106e5048
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Scripts/Infantry/SelectedAuthoring.cs
+++ b/CodexTest/Assets/Scripts/Infantry/SelectedAuthoring.cs
@@ -1,0 +1,23 @@
+using Unity.Entities;
+using UnityEngine;
+
+namespace RTS.Infantry
+{
+    /// <summary>
+    /// Optional authoring that marks the unit as selected at bake time
+    /// by adding the <see cref="SelectedTag"/> component.
+    /// Attach this script to a GameObject to start it selected.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class SelectedAuthoring : MonoBehaviour
+    {
+        class Baker : Baker<SelectedAuthoring>
+        {
+            public override void Bake(SelectedAuthoring authoring)
+            {
+                var entity = GetEntity(TransformUsageFlags.Dynamic);
+                AddComponent<SelectedTag>(entity);
+            }
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Infantry/SelectedAuthoring.cs.meta
+++ b/CodexTest/Assets/Scripts/Infantry/SelectedAuthoring.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6098b1a4c65e421792c3027ab2452fce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- convert infantry prefabs to ECS entities with InfantryTag and NavAgent references
- optional authoring to mark units as initially selected

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: 403  Forbidden and repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68951bada878832185389bfe733004a7