### PR TITLE
Fix infantry selection when clicking child colliders

### DIFF
--- a/CodexTest/Assets/Scripts/Infantry/Systems/SelectionSystem.cs
+++ b/CodexTest/Assets/Scripts/Infantry/Systems/SelectionSystem.cs
@@ -69,7 +69,8 @@ namespace RTS.Infantry
             var ray = _camera.ScreenPointToRay(screenPos);
             if (Physics.Raycast(ray, out var hit))
             {
-                if (hit.transform.TryGetComponent<EntityReference>(out var reference))
+                var reference = hit.transform.GetComponentInParent<EntityReference>();
+                if (reference != null)
                 {
                     var entity = reference.Entity;
                     if (EntityManager.Exists(entity) && EntityManager.HasComponent<InfantryTag>(entity))


### PR DESCRIPTION
## Summary
- Use `GetComponentInParent` to resolve `EntityReference` during single selection

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689522bfc4808321b94f7442f65c4101