### PR TITLE
feat: add ecs foundation and setup guide

### DIFF
--- a/CodexTest/Assets/Scripts/Components/PositionComponent.cs
+++ b/CodexTest/Assets/Scripts/Components/PositionComponent.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+using Game.Domain.ECS;
+
+namespace Game.Components
+{
+    /// <summary>
+    /// Holds world position of an entity.
+    /// Pure data only.
+    /// </summary>
+    public struct PositionComponent : IComponent
+    {
+        public Vector3 Value;
+    }
+}

--- a/CodexTest/Assets/Scripts/Domain/CommandHandler.cs
+++ b/CodexTest/Assets/Scripts/Domain/CommandHandler.cs
@@ -1,0 +1,23 @@
+using Game.Domain.Commands;
+using Game.Infrastructure;
+
+namespace Game.Domain
+{
+    /// <summary>
+    /// Dispatches commands to systems via EventBus.
+    /// </summary>
+    public class CommandHandler
+    {
+        private readonly EventBus _eventBus;
+
+        public CommandHandler(EventBus eventBus)
+        {
+            _eventBus = eventBus;
+        }
+
+        public void Handle(MoveCommand command)
+        {
+            _eventBus.Publish(command);
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Domain/Commands/MoveCommand.cs
+++ b/CodexTest/Assets/Scripts/Domain/Commands/MoveCommand.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+using Game.Domain.ECS;
+
+namespace Game.Domain.Commands
+{
+    /// <summary>
+    /// Command sent by client to request entity movement.
+    /// </summary>
+    public readonly struct MoveCommand
+    {
+        public readonly Entity Entity;
+        public readonly Vector3 Direction;
+        public readonly float Speed;
+
+        public MoveCommand(Entity entity, Vector3 direction, float speed)
+        {
+            Entity = entity;
+            Direction = direction;
+            Speed = speed;
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Domain/ECS/Entity.cs
+++ b/CodexTest/Assets/Scripts/Domain/ECS/Entity.cs
@@ -1,0 +1,17 @@
+namespace Game.Domain.ECS
+{
+    /// <summary>
+    /// Represents a unique identifier of an entity in the ECS world.
+    /// </summary>
+    public readonly struct Entity
+    {
+        public readonly int Id;
+
+        public Entity(int id)
+        {
+            Id = id;
+        }
+
+        public override string ToString() => Id.ToString();
+    }
+}

--- a/CodexTest/Assets/Scripts/Domain/ECS/IComponent.cs
+++ b/CodexTest/Assets/Scripts/Domain/ECS/IComponent.cs
@@ -1,0 +1,8 @@
+namespace Game.Domain.ECS
+{
+    /// <summary>
+    /// Marker interface for all components.
+    /// Components contain only data and no logic.
+    /// </summary>
+    public interface IComponent { }
+}

--- a/CodexTest/Assets/Scripts/Domain/ECS/ISystem.cs
+++ b/CodexTest/Assets/Scripts/Domain/ECS/ISystem.cs
@@ -1,0 +1,11 @@
+namespace Game.Domain.ECS
+{
+    /// <summary>
+    /// Interface for all systems. Systems operate on components and
+    /// are executed by the server.
+    /// </summary>
+    public interface ISystem
+    {
+        void Update(World world, float deltaTime);
+    }
+}

--- a/CodexTest/Assets/Scripts/Domain/ECS/World.cs
+++ b/CodexTest/Assets/Scripts/Domain/ECS/World.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+
+namespace Game.Domain.ECS
+{
+    /// <summary>
+    /// ECS world containing entities and their components.
+    /// Provides basic APIs to manage components.
+    /// </summary>
+    public class World
+    {
+        private int _nextEntityId;
+        private readonly Dictionary<Type, IDictionary<int, IComponent>> _components = new();
+
+        public Entity CreateEntity()
+        {
+            return new Entity(_nextEntityId++);
+        }
+
+        public void AddComponent<T>(Entity entity, T component) where T : IComponent
+        {
+            var type = typeof(T);
+            if (!_components.TryGetValue(type, out var map))
+            {
+                map = new Dictionary<int, IComponent>();
+                _components[type] = map;
+            }
+            map[entity.Id] = component;
+        }
+
+        public bool TryGetComponent<T>(Entity entity, out T component) where T : IComponent
+        {
+            component = default;
+            var type = typeof(T);
+            if (_components.TryGetValue(type, out var map) && map.TryGetValue(entity.Id, out var comp))
+            {
+                component = (T)comp;
+                return true;
+            }
+            return false;
+        }
+
+        public void SetComponent<T>(Entity entity, T component) where T : IComponent
+        {
+            var type = typeof(T);
+            if (_components.TryGetValue(type, out var map))
+            {
+                map[entity.Id] = component;
+            }
+        }
+
+        public IEnumerable<(Entity entity, T component)> View<T>() where T : IComponent
+        {
+            var type = typeof(T);
+            if (_components.TryGetValue(type, out var map))
+            {
+                foreach (var pair in map)
+                {
+                    yield return (new Entity(pair.Key), (T)pair.Value);
+                }
+            }
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
@@ -1,0 +1,33 @@
+using Game.Domain.Commands;
+using Game.Domain.ECS;
+using Game.Networking;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace Game.Infrastructure
+{
+    /// <summary>
+    /// Captures player input on the client and sends it to the server.
+    /// </summary>
+    public class ClientInputSender : MonoBehaviour
+    {
+        [SerializeField] private NetworkManager networkManager;
+        [SerializeField] private float moveSpeed = 5f;
+        private Vector2 moveInput;
+        public Entity PlayerEntity { get; set; }
+
+        public void OnMove(InputAction.CallbackContext context)
+        {
+            moveInput = context.ReadValue<Vector2>();
+        }
+
+        private void Update()
+        {
+            if (moveInput == Vector2.zero)
+                return;
+            var direction = new Vector3(moveInput.x, 0, moveInput.y);
+            var command = new MoveCommand(PlayerEntity, direction, moveSpeed * Time.deltaTime);
+            networkManager.SendMessage(command);
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Infrastructure/EventBus.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/EventBus.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace Game.Infrastructure
+{
+    /// <summary>
+    /// Simple event bus for decoupled communication between systems.
+    /// </summary>
+    public class EventBus
+    {
+        private readonly Dictionary<Type, List<Delegate>> _subscribers = new();
+
+        public void Subscribe<T>(Action<T> handler)
+        {
+            var type = typeof(T);
+            if (!_subscribers.TryGetValue(type, out var handlers))
+            {
+                handlers = new List<Delegate>();
+                _subscribers[type] = handlers;
+            }
+            handlers.Add(handler);
+        }
+
+        public void Unsubscribe<T>(Action<T> handler)
+        {
+            var type = typeof(T);
+            if (_subscribers.TryGetValue(type, out var handlers))
+            {
+                handlers.Remove(handler);
+            }
+        }
+
+        public void Publish<T>(T evt)
+        {
+            var type = typeof(T);
+            if (_subscribers.TryGetValue(type, out var handlers))
+            {
+                foreach (var handler in handlers)
+                {
+                    ((Action<T>)handler)?.Invoke(evt);
+                }
+            }
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
@@ -1,0 +1,35 @@
+using System.Text;
+using System.Text.Json;
+using Unity.Collections;
+using Unity.Networking.Transport;
+using Game.Domain.Commands;
+using Game.Networking;
+
+namespace Game.Infrastructure
+{
+    /// <summary>
+    /// Listens for incoming network data and publishes commands to the event bus.
+    /// </summary>
+    public class ServerCommandDispatcher
+    {
+        private readonly NetworkManager _networkManager;
+        private readonly EventBus _eventBus;
+
+        public ServerCommandDispatcher(NetworkManager networkManager, EventBus eventBus)
+        {
+            _networkManager = networkManager;
+            _eventBus = eventBus;
+            _networkManager.OnData += OnDataReceived;
+        }
+
+        private void OnDataReceived(DataStreamReader stream)
+        {
+            var bytes = new NativeArray<byte>(stream.Length, Allocator.Temp);
+            stream.ReadBytes(bytes);
+            var json = Encoding.UTF8.GetString(bytes.ToArray());
+            bytes.Dispose();
+            var move = JsonSerializer.Deserialize<MoveCommand>(json);
+            _eventBus.Publish(move);
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Networking/NetworkManager.cs
+++ b/CodexTest/Assets/Scripts/Networking/NetworkManager.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Text;
+using System.Text.Json;
+using Unity.Collections;
+using Unity.Networking.Transport;
+
+namespace Game.Networking
+{
+    /// <summary>
+    /// Minimal wrapper around Unity Transport for sending and receiving raw messages.
+    /// Contains no game logic.
+    /// </summary>
+    public class NetworkManager : IDisposable
+    {
+        private NetworkDriver _driver;
+        private NetworkConnection _connection;
+        public event Action<DataStreamReader> OnData;
+
+        public void StartClient(string address, ushort port)
+        {
+            _driver = NetworkDriver.Create();
+            var endpoint = NetworkEndPoint.Parse(address, port);
+            _connection = _driver.Connect(endpoint);
+        }
+
+        public void StartServer(ushort port)
+        {
+            _driver = NetworkDriver.Create();
+            var endpoint = NetworkEndPoint.AnyIpv4;
+            endpoint.Port = port;
+            if (_driver.Bind(endpoint) != 0)
+            {
+                throw new Exception("Failed to bind to port" + port);
+            }
+            _driver.Listen();
+        }
+
+        public void Update()
+        {
+            _driver.ScheduleUpdate().Complete();
+            if (_connection.IsCreated)
+            {
+                DataStreamReader stream;
+                NetworkEvent.Type cmd;
+                while ((cmd = _driver.PopEventForConnection(_connection, out stream)) != NetworkEvent.Type.Empty)
+                {
+                    if (cmd == NetworkEvent.Type.Data)
+                    {
+                        OnData?.Invoke(stream);
+                    }
+                }
+            }
+        }
+
+        public void SendBytes(byte[] bytes)
+        {
+            if (!_connection.IsCreated)
+                return;
+            using var nativeArray = new NativeArray<byte>(bytes, Allocator.Temp);
+            var writer = _driver.BeginSend(_connection);
+            writer.WriteBytes(nativeArray);
+            _driver.EndSend(writer);
+        }
+
+        public void SendMessage<T>(T message)
+        {
+            var json = JsonSerializer.Serialize(message);
+            SendBytes(Encoding.UTF8.GetBytes(json));
+        }
+
+        public void Dispose()
+        {
+            if (_driver.IsCreated)
+            {
+                _driver.Dispose();
+            }
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Systems/MovementSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/MovementSystem.cs
@@ -1,0 +1,37 @@
+using Game.Components;
+using Game.Domain.Commands;
+using Game.Domain.ECS;
+using Game.Infrastructure;
+
+namespace Game.Systems
+{
+    /// <summary>
+    /// Processes MoveCommand events and updates entity positions on the server.
+    /// </summary>
+    public class MovementSystem : ISystem
+    {
+        private readonly World _world;
+        private readonly EventBus _eventBus;
+
+        public MovementSystem(World world, EventBus eventBus)
+        {
+            _world = world;
+            _eventBus = eventBus;
+            _eventBus.Subscribe<MoveCommand>(OnMoveCommand);
+        }
+
+        public void Update(World world, float deltaTime)
+        {
+            // Movement is event driven; no per-frame logic required here.
+        }
+
+        private void OnMoveCommand(MoveCommand command)
+        {
+            if (_world.TryGetComponent(command.Entity, out PositionComponent position))
+            {
+                position.Value += command.Direction.normalized * command.Speed;
+                _world.SetComponent(command.Entity, position);
+            }
+        }
+    }
+}

--- a/SetupGuide.md
+++ b/SetupGuide.md
@@ -1,0 +1,64 @@
+# Setup Guide
+
+This project targets **Unity 2022.3.33f1** and implements a minimal server-authoritative ECS
+foundation.
+
+## Required Unity Packages
+Install via *Window → Package Manager*:
+
+- `com.unity.transport` – Unity Transport for networking
+- `com.unity.inputsystem` – New Input System for capturing player input
+
+## Folder Structure
+Create the following folders under `Assets/`:
+
+```
+Assets/
+  Scripts/
+    Components/
+    Systems/
+    Networking/
+    Domain/
+      Commands/
+      ECS/
+    Infrastructure/
+    Utils/ (reserved)
+```
+
+Place the provided `.cs` files into the matching folders.
+
+## Headless Server Build
+1. Open **File → Build Settings**.
+2. Check **Server Build** to create a headless executable.
+3. In a bootstrap script, create and wire:
+   - `EventBus`
+   - `World`
+   - `NetworkManager` (call `StartServer(port)`)
+   - `ServerCommandDispatcher`
+   - `MovementSystem`
+4. On every tick call `networkManager.Update()` and `movementSystem.Update(world, deltaTime)`.
+
+## Client Scene Setup
+1. In the client scene create a `GameObject` named `Client`.
+2. Add components:
+   - `NetworkManager` (call `StartClient(address, port)` at start)
+   - `ClientInputSender` – reference the `NetworkManager`.
+   - `PlayerInput` (from Input System) with an action *Move* mapped to WASD or stick.
+     Set the action to call `ClientInputSender.OnMove`.
+3. Runtime-created entities should be mirrored on the client for rendering only.
+
+## Local Network Testing
+1. Build and run the server headless (or run a `ServerBootstrap` script in the Editor).
+2. Play the client scene in the Editor or as a standalone build.
+3. Both can run on the same machine using `localhost` and the same port.
+
+## Project Structure Overview
+- **Domain/ECS** – core ECS types (`Entity`, `World`, `ISystem`, `IComponent`).
+- **Components** – data-only components like `PositionComponent`.
+- **Systems** – server systems such as `MovementSystem` reacting to events.
+- **Networking** – `NetworkManager` wrapper around Unity Transport.
+- **Infrastructure** – plumbing: `EventBus`, `ClientInputSender`, `ServerCommandDispatcher`.
+- **Domain/Commands** – command structs (e.g., `MoveCommand`).
+
+This foundation establishes a clean separation of concerns and an event-driven,
+server-authoritative workflow ready for further expansion.


### PR DESCRIPTION
## Summary
- establish minimal ECS core (Entity, World, IComponent, ISystem)
- add PositionComponent, MoveCommand, and MovementSystem reacting via EventBus
- implement NetworkManager, client input sender, and server command dispatcher
- document Unity setup steps in SetupGuide

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895d921e7108321b43f505900dbc093