### PR TITLE
Add ECS bootstraps and setup guide

### DIFF
--- a/CodexTest/Assets/Scripts/Domain/Events/PositionChangedEvent.cs
+++ b/CodexTest/Assets/Scripts/Domain/Events/PositionChangedEvent.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+using Game.Domain.ECS;
+
+namespace Game.Domain.Events
+{
+    /// <summary>
+    /// Raised when an entity's position changes on the server.
+    /// </summary>
+    public readonly struct PositionChangedEvent
+    {
+        public readonly Entity Entity;
+        public readonly Vector3 Position;
+
+        public PositionChangedEvent(Entity entity, Vector3 position)
+        {
+            Entity = entity;
+            Position = position;
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
@@ -1,0 +1,46 @@
+using Game.Domain.ECS;
+using Game.Networking;
+using Game.Presentation;
+using UnityEngine;
+
+namespace Game.Infrastructure
+{
+    /// <summary>
+    /// Starts the client network connection and wires up input and camera.
+    /// </summary>
+    public class ClientBootstrap : MonoBehaviour
+    {
+        [SerializeField] private string address = "127.0.0.1";
+        [SerializeField] private ushort port = 7777;
+        [SerializeField] private ClientInputSender inputSender;
+        [SerializeField] private Transform playerVisual;
+        [SerializeField] private CameraFollow cameraFollow;
+        [SerializeField] private ClientSnapshotReceiver snapshotReceiver;
+
+        private NetworkManager networkManager;
+
+        private void Start()
+        {
+            networkManager = new NetworkManager();
+            networkManager.StartClient(address, port);
+
+            var playerEntity = new Entity(0); // Match server-spawned entity ID
+            inputSender.Initialize(networkManager, playerEntity);
+            snapshotReceiver.Initialize(networkManager, playerVisual);
+            if (cameraFollow != null && playerVisual != null)
+            {
+                cameraFollow.SetTarget(playerVisual);
+            }
+        }
+
+        private void Update()
+        {
+            networkManager.Update();
+        }
+
+        private void OnDestroy()
+        {
+            networkManager?.Dispose();
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
@@ -11,10 +11,19 @@ namespace Game.Infrastructure
     /// </summary>
     public class ClientInputSender : MonoBehaviour
     {
-        [SerializeField] private NetworkManager networkManager;
+        private NetworkManager networkManager;
         [SerializeField] private float moveSpeed = 5f;
         private Vector2 moveInput;
-        public Entity PlayerEntity { get; set; }
+        public Entity PlayerEntity { get; private set; }
+
+        /// <summary>
+        /// Injects dependencies from ClientBootstrap.
+        /// </summary>
+        public void Initialize(NetworkManager manager, Entity playerEntity)
+        {
+            networkManager = manager;
+            PlayerEntity = playerEntity;
+        }
 
         public void OnMove(InputAction.CallbackContext context)
         {

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientSnapshotReceiver.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientSnapshotReceiver.cs
@@ -1,0 +1,47 @@
+using System.Text;
+using System.Text.Json;
+using Game.Networking;
+using Game.Networking.Messages;
+using Unity.Collections;
+using Unity.Networking.Transport;
+using UnityEngine;
+
+namespace Game.Infrastructure
+{
+    /// <summary>
+    /// Receives position snapshots from the server and applies them to the player visual.
+    /// </summary>
+    public class ClientSnapshotReceiver : MonoBehaviour
+    {
+        private NetworkManager networkManager;
+        private Transform playerVisual;
+
+        public void Initialize(NetworkManager manager, Transform target)
+        {
+            networkManager = manager;
+            playerVisual = target;
+            networkManager.OnData += OnDataReceived;
+        }
+
+        private void OnDataReceived(DataStreamReader stream)
+        {
+            var bytes = new NativeArray<byte>(stream.Length, Allocator.Temp);
+            stream.ReadBytes(bytes);
+            var json = Encoding.UTF8.GetString(bytes.ToArray());
+            bytes.Dispose();
+            var snapshot = JsonSerializer.Deserialize<PositionSnapshot>(json);
+            if (snapshot.EntityId == 0 && playerVisual != null)
+            {
+                playerVisual.position = snapshot.Position;
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (networkManager != null)
+            {
+                networkManager.OnData -= OnDataReceived;
+            }
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
@@ -1,0 +1,56 @@
+using Game.Components;
+using Game.Domain;
+using Game.Domain.ECS;
+using Game.Infrastructure;
+using Game.Networking;
+using Game.Systems;
+using Game.Domain.Events;
+using UnityEngine;
+
+namespace Game.Infrastructure
+{
+    /// <summary>
+    /// Initializes server-side systems and runs the authoritative simulation.
+    /// </summary>
+    public class ServerBootstrap : MonoBehaviour
+    {
+        [SerializeField] private ushort port = 7777;
+
+        private World world;
+        private EventBus eventBus;
+        private NetworkManager networkManager;
+        private MovementSystem movementSystem;
+        private ReplicationSystem replicationSystem;
+        private ServerCommandDispatcher dispatcher;
+        private CommandHandler commandHandler;
+
+        private void Start()
+        {
+            eventBus = new EventBus();
+            world = new World();
+            networkManager = new NetworkManager();
+            networkManager.StartServer(port);
+            dispatcher = new ServerCommandDispatcher(networkManager, eventBus);
+            movementSystem = new MovementSystem(world, eventBus);
+            replicationSystem = new ReplicationSystem(networkManager, eventBus);
+            commandHandler = new CommandHandler(eventBus);
+
+            // Spawn a single player entity at the origin.
+            var player = world.CreateEntity();
+            world.AddComponent(player, new PositionComponent { Value = Vector3.zero });
+            eventBus.Publish(new PositionChangedEvent(player, Vector3.zero));
+        }
+
+        private void Update()
+        {
+            networkManager.Update();
+            movementSystem.Update(world, Time.deltaTime);
+            replicationSystem.Update(world, Time.deltaTime);
+        }
+
+        private void OnDestroy()
+        {
+            networkManager?.Dispose();
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Networking/Messages/PositionSnapshot.cs
+++ b/CodexTest/Assets/Scripts/Networking/Messages/PositionSnapshot.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+using Game.Domain.ECS;
+
+namespace Game.Networking.Messages
+{
+    /// <summary>
+    /// Snapshot message sent from server to clients with entity position.
+    /// </summary>
+    public readonly struct PositionSnapshot
+    {
+        public readonly int EntityId;
+        public readonly Vector3 Position;
+
+        public PositionSnapshot(Entity entity, Vector3 position)
+        {
+            EntityId = entity.Id;
+            Position = position;
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Networking/NetworkManager.cs
+++ b/CodexTest/Assets/Scripts/Networking/NetworkManager.cs
@@ -38,6 +38,17 @@ namespace Game.Networking
         public void Update()
         {
             _driver.ScheduleUpdate().Complete();
+
+            if (_driver.IsCreated && !_connection.IsCreated)
+            {
+                // Accept incoming connection on the server.
+                var connection = _driver.Accept();
+                if (connection.IsCreated)
+                {
+                    _connection = connection;
+                }
+            }
+
             if (_connection.IsCreated)
             {
                 DataStreamReader stream;
@@ -47,6 +58,10 @@ namespace Game.Networking
                     if (cmd == NetworkEvent.Type.Data)
                     {
                         OnData?.Invoke(stream);
+                    }
+                    else if (cmd == NetworkEvent.Type.Disconnect)
+                    {
+                        _connection = default;
                     }
                 }
             }

--- a/CodexTest/Assets/Scripts/Presentation/CameraFollow.cs
+++ b/CodexTest/Assets/Scripts/Presentation/CameraFollow.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+namespace Game.Presentation
+{
+    /// <summary>
+    /// Simple top-down camera that follows a target transform.
+    /// Presentation only; no gameplay logic.
+    /// </summary>
+    public class CameraFollow : MonoBehaviour
+    {
+        [SerializeField] private Transform target;
+        [SerializeField] private Vector3 offset = new Vector3(0, 10, -10);
+        [SerializeField] private float followSpeed = 5f;
+
+        private void LateUpdate()
+        {
+            if (target == null) return;
+            var desired = target.position + offset;
+            transform.position = Vector3.Lerp(transform.position, desired, followSpeed * Time.deltaTime);
+            transform.LookAt(target);
+        }
+
+        public void SetTarget(Transform newTarget)
+        {
+            target = newTarget;
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Systems/MovementSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/MovementSystem.cs
@@ -1,6 +1,7 @@
 using Game.Components;
 using Game.Domain.Commands;
 using Game.Domain.ECS;
+using Game.Domain.Events;
 using Game.Infrastructure;
 
 namespace Game.Systems
@@ -31,6 +32,7 @@ namespace Game.Systems
             {
                 position.Value += command.Direction.normalized * command.Speed;
                 _world.SetComponent(command.Entity, position);
+                _eventBus.Publish(new PositionChangedEvent(command.Entity, position.Value));
             }
         }
     }

--- a/CodexTest/Assets/Scripts/Systems/ReplicationSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/ReplicationSystem.cs
@@ -1,0 +1,35 @@
+using Game.Domain.ECS;
+using Game.Domain.Events;
+using Game.Networking;
+using Game.Networking.Messages;
+using Game.Infrastructure;
+
+namespace Game.Systems
+{
+    /// <summary>
+    /// Sends position snapshots to clients when entities move.
+    /// </summary>
+    public class ReplicationSystem : ISystem
+    {
+        private readonly NetworkManager _networkManager;
+        private readonly EventBus _eventBus;
+
+        public ReplicationSystem(NetworkManager networkManager, EventBus eventBus)
+        {
+            _networkManager = networkManager;
+            _eventBus = eventBus;
+            _eventBus.Subscribe<PositionChangedEvent>(OnPositionChanged);
+        }
+
+        public void Update(World world, float deltaTime)
+        {
+            // Replication is event-driven; nothing per-frame here.
+        }
+
+        private void OnPositionChanged(PositionChangedEvent evt)
+        {
+            var snapshot = new PositionSnapshot(evt.Entity, evt.Position);
+            _networkManager.SendMessage(snapshot);
+        }
+    }
+}

--- a/SetupGuide.md
+++ b/SetupGuide.md
@@ -1,15 +1,14 @@
 # Setup Guide
 
-This project targets **Unity 2022.3.33f1** and implements a minimal server-authoritative ECS
-foundation.
+This repository demonstrates a minimal server-authoritative ECS framework for **Unity 2022.3.33f1**. Follow these steps to set up the project and run both client and server on the same machine.
 
-## Required Unity Packages
-Install via *Window → Package Manager*:
+## 1. Install Unity Packages
+Open **Window → Package Manager** and install:
 
 - `com.unity.transport` – Unity Transport for networking
-- `com.unity.inputsystem` – New Input System for capturing player input
+- `com.unity.inputsystem` – Input System for capturing player input
 
-## Folder Structure
+## 2. Create Folder Structure
 Create the following folders under `Assets/`:
 
 ```
@@ -22,43 +21,46 @@ Assets/
       Commands/
       ECS/
     Infrastructure/
-    Utils/ (reserved)
+    Presentation/
+    Utils/        (reserved)
 ```
 
-Place the provided `.cs` files into the matching folders.
+Place the provided `.cs` files into their matching folders.
 
-## Headless Server Build
-1. Open **File → Build Settings**.
-2. Check **Server Build** to create a headless executable.
-3. In a bootstrap script, create and wire:
+## 3. Server Bootstrap (Headless)
+1. Create an empty scene for the server.
+2. Add a `GameObject` named **Server** and attach `ServerBootstrap`.
+3. `ServerBootstrap` wires together:
    - `EventBus`
    - `World`
-   - `NetworkManager` (call `StartServer(port)`)
+   - `NetworkManager` (`StartServer(port)`)
    - `ServerCommandDispatcher`
    - `MovementSystem`
-4. On every tick call `networkManager.Update()` and `movementSystem.Update(world, deltaTime)`.
+   - `ReplicationSystem`
+4. Open **File → Build Settings** and enable **Server Build** to produce a headless executable.
 
-## Client Scene Setup
-1. In the client scene create a `GameObject` named `Client`.
-2. Add components:
-   - `NetworkManager` (call `StartClient(address, port)` at start)
-   - `ClientInputSender` – reference the `NetworkManager`.
-   - `PlayerInput` (from Input System) with an action *Move* mapped to WASD or stick.
-     Set the action to call `ClientInputSender.OnMove`.
-3. Runtime-created entities should be mirrored on the client for rendering only.
+## 4. Client Scene
+1. Create a new scene for the client.
+2. Add an empty `GameObject` named **Client** and attach `ClientBootstrap`.
+3. `ClientBootstrap` references:
+   - `ClientInputSender`
+   - `ClientSnapshotReceiver`
+   - a player visual `Transform` used for rendering
+   - `CameraFollow` on the main camera for top‑down tracking
+4. Add a `PlayerInput` component with an action **Move** bound to WASD/left stick and set it to call `ClientInputSender.OnMove`.
+5. The client only renders state and sends input; all gameplay logic runs on the server.
 
-## Local Network Testing
-1. Build and run the server headless (or run a `ServerBootstrap` script in the Editor).
+## 5. Running Locally
+1. Start the headless server build or play the server scene in the Editor.
 2. Play the client scene in the Editor or as a standalone build.
-3. Both can run on the same machine using `localhost` and the same port.
+3. Use `localhost` and the same port so both run on one machine.
 
-## Project Structure Overview
+## 6. Project Overview
 - **Domain/ECS** – core ECS types (`Entity`, `World`, `ISystem`, `IComponent`).
-- **Components** – data-only components like `PositionComponent`.
-- **Systems** – server systems such as `MovementSystem` reacting to events.
+- **Components** – data-only components such as `PositionComponent`.
+- **Systems** – server logic like `MovementSystem` responding to events.
 - **Networking** – `NetworkManager` wrapper around Unity Transport.
-- **Infrastructure** – plumbing: `EventBus`, `ClientInputSender`, `ServerCommandDispatcher`.
-- **Domain/Commands** – command structs (e.g., `MoveCommand`).
+- **Infrastructure** – glue code (`EventBus`, `ClientInputSender`, `ServerCommandDispatcher`, `ClientBootstrap`, `ServerBootstrap`).
+- **Presentation** – visuals and camera scripts (`CameraFollow`).
 
-This foundation establishes a clean separation of concerns and an event-driven,
-server-authoritative workflow ready for further expansion.
+This setup yields a clean, event-driven, server‑authoritative ECS base where a player entity moves with WASD, the server replicates the position, and the client camera follows from a top‑down perspective.


### PR DESCRIPTION
## Summary
- Add ReplicationSystem and PositionSnapshot to send server-side position updates
- Handle snapshots on the client with ClientSnapshotReceiver and NetworkManager connection acceptance
- Update bootstraps and SetupGuide for the replication workflow

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895e08cae98832192d4c5ef684f51d6