### PR TITLE
Fix missing Unity Transport imports

### DIFF
--- a/CodexTest/Assets/Scripts/Networking/NetworkManager.cs
+++ b/CodexTest/Assets/Scripts/Networking/NetworkManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using System.Text.Json;
 using Unity.Collections;
+using Unity.Networking.Transport;
 
 
 namespace Game.Networking


### PR DESCRIPTION
## Summary
- include Unity Transport namespace in NetworkManager to resolve missing NetworkDriver and NetworkConnection types

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6895ef1c951483218e9c5ecb581ba503