### PR TITLE
fix: use JsonUtility and correct send API

### DIFF
--- a/CodexTest/Assets/Scripts/Infrastructure/ClientSnapshotReceiver.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientSnapshotReceiver.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Text.Json;
 using Game.Networking;
 using Game.Networking.Messages;
 using Unity.Collections;
@@ -28,7 +27,7 @@ namespace Game.Infrastructure
             using var bytes = new NativeArray<byte>(stream.Length, Allocator.Temp);
             stream.ReadBytes(bytes);
             var json = Encoding.UTF8.GetString(bytes.ToArray());
-            var snapshot = JsonSerializer.Deserialize<PositionSnapshot>(json);
+            var snapshot = JsonUtility.FromJson<PositionSnapshot>(json);
             if (snapshot != null && playerVisual != null && snapshot.EntityId == 0)
             {
                 playerVisual.position = snapshot.Position;

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Text;
-using System.Text.Json;
 using Unity.Collections;
 using Unity.Networking.Transport;
+using UnityEngine;
 
 using Game.Domain.Commands;
 using Game.Networking;
@@ -29,7 +29,7 @@ namespace Game.Infrastructure
             using var bytes = new NativeArray<byte>(stream.Length, Allocator.Temp);
             stream.ReadBytes(bytes);
             var json = Encoding.UTF8.GetString(bytes.ToArray());
-            var move = JsonSerializer.Deserialize<MoveCommand>(json);
+            var move = JsonUtility.FromJson<MoveCommand>(json);
             if (move != null)
             {
                 _eventBus.Publish(move);

--- a/CodexTest/Assets/Scripts/Networking/NetworkManager.cs
+++ b/CodexTest/Assets/Scripts/Networking/NetworkManager.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Text;
-using System.Text.Json;
 using Unity.Collections;
 using Unity.Networking.Transport;
+using UnityEngine;
 
 
 namespace Game.Networking
@@ -75,14 +75,16 @@ namespace Game.Networking
             if (!_connection.IsCreated)
                 return;
             using var nativeArray = new NativeArray<byte>(bytes, Allocator.Temp);
-            var writer = _driver.BeginSend(_connection);
-            writer.WriteBytes(nativeArray);
-            _driver.EndSend(writer);
+            if (_driver.BeginSend(_connection, out var writer) == 0)
+            {
+                writer.WriteBytes(nativeArray);
+                _driver.EndSend(writer);
+            }
         }
 
         public void SendMessage<T>(T message)
         {
-            var json = JsonSerializer.Serialize(message);
+            var json = JsonUtility.ToJson(message);
             SendBytes(Encoding.UTF8.GetBytes(json));
         }
 


### PR DESCRIPTION
## Summary
- replace System.Text.Json with UnityEngine.JsonUtility for deserialization/serialization
- fix Unity Transport BeginSend usage in NetworkManager

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6895f69385548321affd1e7c72b1aebe