### PR TITLE
fix: handle struct deserialization

### DIFF
--- a/CodexTest/Assets/Scripts/Infrastructure/ClientSnapshotReceiver.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientSnapshotReceiver.cs
@@ -28,7 +28,7 @@ namespace Game.Infrastructure
             stream.ReadBytes(bytes);
             var json = Encoding.UTF8.GetString(bytes.ToArray());
             var snapshot = JsonUtility.FromJson<PositionSnapshot>(json);
-            if (snapshot != null && playerVisual != null && snapshot.EntityId == 0)
+            if (!snapshot.Equals(default(PositionSnapshot)) && playerVisual != null && snapshot.EntityId == 0)
             {
                 playerVisual.position = snapshot.Position;
             }

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
@@ -30,7 +30,7 @@ namespace Game.Infrastructure
             stream.ReadBytes(bytes);
             var json = Encoding.UTF8.GetString(bytes.ToArray());
             var move = JsonUtility.FromJson<MoveCommand>(json);
-            if (move != null)
+            if (!move.Equals(default(MoveCommand)))
             {
                 _eventBus.Publish(move);
             }


### PR DESCRIPTION
## Summary
- avoid null checks on struct commands and snapshots

## Testing
- `mcs CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs CodexTest/Assets/Scripts/Infrastructure/ClientSnapshotReceiver.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895f8a0f7648321aa32f0bbc6ae4f92