### PR TITLE
feat: send move command on input

### DIFF
--- a/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
@@ -13,7 +13,6 @@ namespace Game.Infrastructure
     {
         private NetworkManager networkManager;
         [SerializeField] private float moveSpeed = 5f;
-        private Vector2 moveInput;
         public Entity PlayerEntity { get; private set; }
 
         /// <summary>
@@ -25,16 +24,20 @@ namespace Game.Infrastructure
             PlayerEntity = playerEntity;
         }
 
+        /// <summary>
+        /// Called by Unity's Input System when the Move action is triggered.
+        /// Translates the 2D input into a 3D direction and sends a MoveCommand
+        /// to the server. Movement occurs only on the server.
+        /// </summary>
         public void OnMove(InputAction.CallbackContext context)
         {
-            moveInput = context.ReadValue<Vector2>();
-        }
-
-        private void Update()
-        {
-            if (moveInput == Vector2.zero)
+            if (!context.performed)
                 return;
-            var direction = new Vector3(moveInput.x, 0, moveInput.y);
+            Vector2 input = context.ReadValue<Vector2>();
+            if (input == Vector2.zero)
+                return;
+
+            var direction = new Vector3(input.x, 0f, input.y);
             var command = new MoveCommand(PlayerEntity, direction, moveSpeed * Time.deltaTime);
             networkManager.SendMessage(command);
         }

--- a/SetupGuide.md
+++ b/SetupGuide.md
@@ -37,7 +37,7 @@ Place the provided `.cs` files into their matching folders.
    - `ServerCommandDispatcher`
    - `MovementSystem`
    - `ReplicationSystem`
-4. Open **File → Build Settings** and enable **Server Build** to produce a headless executable.
+4. Open **File → Build Settings** and enable **Dedicated Server/Server Build** to produce a headless executable. (Leave this unchecked for client builds.)
 
 ## 4. Client Scene
 1. Create a new scene for the client.
@@ -47,7 +47,10 @@ Place the provided `.cs` files into their matching folders.
    - `ClientSnapshotReceiver`
    - a player visual `Transform` used for rendering
    - `CameraFollow` on the main camera for top‑down tracking
-4. Add a `PlayerInput` component with an action **Move** bound to WASD/left stick and set it to call `ClientInputSender.OnMove`.
+4. Add a `PlayerInput` component:
+   - Create an **Input Actions** asset with an action map `Gameplay` and a `Vector2` action **Move** bound to WASD/left stick.
+   - In `PlayerInput`, assign this asset and choose **Invoke Unity Events**.
+   - Under **Move (performed)**, hook up `ClientInputSender → OnMove`.
 5. The client only renders state and sends input; all gameplay logic runs on the server.
 
 ## 5. Running on One Machine


### PR DESCRIPTION
## Summary
- dispatch move commands directly from `ClientInputSender.OnMove`
- clarify client setup and server build steps in SetupGuide

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_6895fb6438f88321a014507157d6babc