### PR TITLE
Implement continuous movement with raw speed commands

### DIFF
--- a/CodexTest/Assets/Scripts/Domain/Commands/MoveCommand.cs
+++ b/CodexTest/Assets/Scripts/Domain/Commands/MoveCommand.cs
@@ -5,11 +5,16 @@ namespace Game.Domain.Commands
 {
     /// <summary>
     /// Command sent by client to request entity movement.
+    /// Direction is the desired movement vector and Speed is expressed
+    /// in units per second.
     /// </summary>
     public readonly struct MoveCommand
     {
         public readonly Entity Entity;
         public readonly Vector3 Direction;
+        /// <summary>
+        /// Movement speed in units per second.
+        /// </summary>
         public readonly float Speed;
 
         public MoveCommand(Entity entity, Vector3 direction, float speed)

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
@@ -13,6 +13,7 @@ namespace Game.Infrastructure
     {
         private NetworkManager networkManager;
         [SerializeField] private float moveSpeed = 5f;
+        private Vector2 _input;
         public Entity PlayerEntity { get; private set; }
 
         /// <summary>
@@ -26,19 +27,28 @@ namespace Game.Infrastructure
 
         /// <summary>
         /// Called by Unity's Input System when the Move action is triggered.
-        /// Translates the 2D input into a 3D direction and sends a MoveCommand
-        /// to the server. Movement occurs only on the server.
+        /// Stores the current 2D input direction. Actual commands are sent
+        /// each frame from Update for smooth continuous movement.
         /// </summary>
         public void OnMove(InputAction.CallbackContext context)
         {
-            if (!context.performed)
-                return;
-            Vector2 input = context.ReadValue<Vector2>();
-            if (input == Vector2.zero)
+            if (context.performed)
+            {
+                _input = context.ReadValue<Vector2>();
+            }
+            else if (context.canceled)
+            {
+                _input = Vector2.zero;
+            }
+        }
+
+        private void Update()
+        {
+            if (_input == Vector2.zero)
                 return;
 
-            var direction = new Vector3(input.x, 0f, input.y);
-            var command = new MoveCommand(PlayerEntity, direction, moveSpeed * Time.deltaTime);
+            var direction = new Vector3(_input.x, 0f, _input.y);
+            var command = new MoveCommand(PlayerEntity, direction, moveSpeed);
             networkManager.SendMessage(command);
         }
     }

--- a/CodexTest/Assets/Scripts/Systems/MovementSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/MovementSystem.cs
@@ -13,6 +13,7 @@ namespace Game.Systems
     {
         private readonly World _world;
         private readonly EventBus _eventBus;
+        private float _deltaTime;
 
         public MovementSystem(World world, EventBus eventBus)
         {
@@ -23,14 +24,16 @@ namespace Game.Systems
 
         public void Update(World world, float deltaTime)
         {
-            // Movement is event driven; no per-frame logic required here.
+            // Store server delta time so that MoveCommand processing can
+            // apply speed consistently each frame.
+            _deltaTime = deltaTime;
         }
 
         private void OnMoveCommand(MoveCommand command)
         {
             if (_world.TryGetComponent(command.Entity, out PositionComponent position))
             {
-                position.Value += command.Direction.normalized * command.Speed;
+                position.Value += command.Direction.normalized * command.Speed * _deltaTime;
                 _world.SetComponent(command.Entity, position);
                 _eventBus.Publish(new PositionChangedEvent(command.Entity, position.Value));
             }


### PR DESCRIPTION
## Summary
- Send movement input each frame and maintain current input state on the client
- Represent MoveCommand speed as raw units per second
- Apply server deltaTime when processing movement commands

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68960c6ade288321a4fa33d45ad2271d