### PR TITLE
Ensure command and snapshot serialization

### DIFF
--- a/CodexTest/Assets/Scripts/Domain/Commands/MoveCommand.cs
+++ b/CodexTest/Assets/Scripts/Domain/Commands/MoveCommand.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using Game.Domain.ECS;
 
@@ -6,6 +7,7 @@ namespace Game.Domain.Commands
     /// <summary>
     /// Command sent by client to request entity movement.
     /// </summary>
+    [Serializable]
     public readonly struct MoveCommand
     {
         public readonly Entity Entity;

--- a/CodexTest/Assets/Scripts/Domain/ECS/Entity.cs
+++ b/CodexTest/Assets/Scripts/Domain/ECS/Entity.cs
@@ -1,8 +1,11 @@
+using System;
+
 namespace Game.Domain.ECS
 {
     /// <summary>
     /// Represents a unique identifier of an entity in the ECS world.
     /// </summary>
+    [Serializable]
     public readonly struct Entity
     {
         public readonly int Id;

--- a/CodexTest/Assets/Scripts/Networking/Messages/PositionSnapshot.cs
+++ b/CodexTest/Assets/Scripts/Networking/Messages/PositionSnapshot.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using Game.Domain.ECS;
 
@@ -6,6 +7,7 @@ namespace Game.Networking.Messages
     /// <summary>
     /// Snapshot message sent from server to clients with entity position.
     /// </summary>
+    [Serializable]
     public readonly struct PositionSnapshot
     {
         public readonly int EntityId;


### PR DESCRIPTION
## Summary
- mark MoveCommand, Entity, and PositionSnapshot structs as `[Serializable]` to enable Unity JsonUtility to serialize IDs and movement data

## Testing
- `dotnet run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68960c62911c83218df6e2dbc6ef6a4e