### PR TITLE
Fix client input handling and snapshot parsing

### DIFF
--- a/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
@@ -48,8 +48,12 @@ namespace Game.Infrastructure
             if (_input == Vector2.zero)
                 return;
 
-            var direction = new Vector3(input.x, 0f, input.y);
-            var command = new MoveCommand(PlayerEntity, direction, moveSpeed * Time.deltaTime);
+            var direction = new Vector3(_input.x, 0f, _input.y);
+
+            // Client-side prediction so the player moves immediately while waiting for server snapshots.
+            transform.Translate(direction.normalized * moveSpeed * Time.deltaTime, Space.World);
+
+            var command = new MoveCommand(PlayerEntity, direction, moveSpeed);
             var payload = JsonUtility.ToJson(command);
             var message = new NetworkMessage(MessageType.MoveCommand, payload);
             networkManager.SendMessage(message);

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientSnapshotReceiver.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientSnapshotReceiver.cs
@@ -27,7 +27,12 @@ namespace Game.Infrastructure
             using var bytes = new NativeArray<byte>(stream.Length, Allocator.Temp);
             stream.ReadBytes(bytes);
             var json = Encoding.UTF8.GetString(bytes.ToArray());
-            var snapshot = JsonUtility.FromJson<PositionSnapshot>(json);
+
+            var message = JsonUtility.FromJson<NetworkMessage>(json);
+            if (message.Type != MessageType.PositionSnapshot)
+                return;
+
+            var snapshot = JsonUtility.FromJson<PositionSnapshot>(message.Payload);
             if (!snapshot.Equals(default(PositionSnapshot)) && playerVisual != null && snapshot.EntityId == 0)
             {
                 playerVisual.position = snapshot.Position;


### PR DESCRIPTION
## Summary
- Use stored input vector and add client-side prediction when sending move commands
- Parse position snapshots via network message envelope

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68960f6dd6f08321878a26ee7a544d6a