### PR TITLE
feat: broadcast to multiple clients

### DIFF
--- a/CodexTest/Assets/Scripts/Domain/Commands/JumpCommand.cs
+++ b/CodexTest/Assets/Scripts/Domain/Commands/JumpCommand.cs
@@ -12,9 +12,18 @@ namespace Game.Domain.Commands
     {
         public readonly Entity Entity;
         public readonly float Force;
+        public readonly int ClientId;
 
         public JumpCommand(Entity entity, float force)
         {
+            Entity = entity;
+            Force = force;
+            ClientId = 0;
+        }
+
+        public JumpCommand(int clientId, Entity entity, float force)
+        {
+            ClientId = clientId;
             Entity = entity;
             Force = force;
         }

--- a/CodexTest/Assets/Scripts/Domain/Commands/MoveCommand.cs
+++ b/CodexTest/Assets/Scripts/Domain/Commands/MoveCommand.cs
@@ -18,9 +18,19 @@ namespace Game.Domain.Commands
         /// Movement speed in units per second.
         /// </summary>
         public readonly float Speed;
+        public readonly int ClientId;
 
         public MoveCommand(Entity entity, Vector3 direction, float speed)
         {
+            Entity = entity;
+            Direction = direction;
+            Speed = speed;
+            ClientId = 0;
+        }
+
+        public MoveCommand(int clientId, Entity entity, Vector3 direction, float speed)
+        {
+            ClientId = clientId;
             Entity = entity;
             Direction = direction;
             Speed = speed;

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientSnapshotReceiver.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientSnapshotReceiver.cs
@@ -22,7 +22,7 @@ namespace Game.Infrastructure
             networkManager.OnData += OnDataReceived;
         }
 
-        private void OnDataReceived(DataStreamReader stream)
+        private void OnDataReceived(int _, DataStreamReader stream)
         {
             using var bytes = new NativeArray<byte>(stream.Length, Allocator.Temp);
             stream.ReadBytes(bytes);

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
@@ -31,6 +31,8 @@ namespace Game.Infrastructure
             world = new World();
             networkManager = new NetworkManager();
             networkManager.StartServer(port);
+            networkManager.OnClientConnected += OnClientConnected;
+            networkManager.OnClientDisconnected += OnClientDisconnected;
             dispatcher = new ServerCommandDispatcher(networkManager, eventBus);
             movementSystem = new MovementSystem(world, eventBus);
             replicationSystem = new ReplicationSystem(networkManager, eventBus);
@@ -53,7 +55,22 @@ namespace Game.Infrastructure
 
         private void OnDestroy()
         {
-            networkManager?.Dispose();
+            if (networkManager != null)
+            {
+                networkManager.OnClientConnected -= OnClientConnected;
+                networkManager.OnClientDisconnected -= OnClientDisconnected;
+                networkManager.Dispose();
+            }
+        }
+
+        private void OnClientConnected(int clientId)
+        {
+            Debug.Log($"Client {clientId} connected");
+        }
+
+        private void OnClientDisconnected(int clientId)
+        {
+            Debug.Log($"Client {clientId} disconnected");
         }
     }
 }


### PR DESCRIPTION
## Summary
- track multiple connections and broadcast network messages to all peers
- publish server commands with client identifiers
- hook server bootstrap to connection events for logging

## Testing
- `ls Assets/Tests` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_689a55b817fc8321ac5a3517033cb323