### PR TITLE
Fix network command serialization in Unity ECS sample

### DIFF
--- a/CodexTest/Assets/Scripts/Domain/Commands/JumpCommand.cs
+++ b/CodexTest/Assets/Scripts/Domain/Commands/JumpCommand.cs
@@ -8,11 +8,11 @@ namespace Game.Domain.Commands
     /// Force represents the initial upward velocity applied.
     /// </summary>
     [Serializable]
-    public readonly struct JumpCommand
+    public struct JumpCommand
     {
-        public readonly Entity Entity;
-        public readonly float Force;
-        public readonly int ClientId;
+        public Entity Entity;
+        public float Force;
+        public int ClientId;
 
         public JumpCommand(Entity entity, float force)
         {

--- a/CodexTest/Assets/Scripts/Domain/Commands/MoveCommand.cs
+++ b/CodexTest/Assets/Scripts/Domain/Commands/MoveCommand.cs
@@ -10,15 +10,15 @@ namespace Game.Domain.Commands
     /// in units per second.
     /// </summary>
     [Serializable]
-    public readonly struct MoveCommand
+    public struct MoveCommand
     {
-        public readonly Entity Entity;
-        public readonly Vector3 Direction;
+        public Entity Entity;
+        public Vector3 Direction;
         /// <summary>
         /// Movement speed in units per second.
         /// </summary>
-        public readonly float Speed;
-        public readonly int ClientId;
+        public float Speed;
+        public int ClientId;
 
         public MoveCommand(Entity entity, Vector3 direction, float speed)
         {

--- a/CodexTest/Assets/Scripts/Networking/Messages/NetworkMessage.cs
+++ b/CodexTest/Assets/Scripts/Networking/Messages/NetworkMessage.cs
@@ -14,10 +14,10 @@ namespace Game.Networking.Messages
     /// Envelope for all network messages.
     /// </summary>
     [Serializable]
-    public readonly struct NetworkMessage
+    public struct NetworkMessage
     {
-        public readonly MessageType Type;
-        public readonly string Payload;
+        public MessageType Type;
+        public string Payload;
 
         public NetworkMessage(MessageType type, string payload)
         {

--- a/CodexTest/Assets/Scripts/Networking/Messages/PositionSnapshot.cs
+++ b/CodexTest/Assets/Scripts/Networking/Messages/PositionSnapshot.cs
@@ -8,10 +8,10 @@ namespace Game.Networking.Messages
     /// Snapshot message sent from server to clients with entity position.
     /// </summary>
     [Serializable]
-    public readonly struct PositionSnapshot
+    public struct PositionSnapshot
     {
-        public readonly int EntityId;
-        public readonly Vector3 Position;
+        public int EntityId;
+        public Vector3 Position;
 
         public PositionSnapshot(Entity entity, Vector3 position)
         {

--- a/CodexTest/Assets/Scripts/Networking/Messages/SpawnPlayer.cs
+++ b/CodexTest/Assets/Scripts/Networking/Messages/SpawnPlayer.cs
@@ -7,9 +7,9 @@ namespace Game.Networking.Messages
     /// Message sent from server to client to inform about the spawned player entity.
     /// </summary>
     [Serializable]
-    public readonly struct SpawnPlayer
+    public struct SpawnPlayer
     {
-        public readonly int EntityId;
+        public int EntityId;
 
         public SpawnPlayer(Entity entity)
         {


### PR DESCRIPTION
## Summary
- make network and command messages mutable so Unity `JsonUtility` can deserialize them
- restore server processing of move and jump commands for player control

## Testing
- `ls CodexTest/Assets/Tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b7118bbf08321bb06849475e7d3fe