### PR TITLE
Fix client jump and prefab visual synchronization

### DIFF
--- a/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
@@ -42,7 +42,10 @@ namespace Game.Infrastructure
 
             var spawn = JsonUtility.FromJson<SpawnPlayer>(message.Payload);
             var entity = new Entity(spawn.EntityId);
-            inputSender.Initialize(networkManager, entity);
+            if (inputSender != null)
+            {
+                inputSender.Initialize(networkManager, entity, playerVisual);
+            }
             snapshotReceiver.Initialize(networkManager, playerVisual);
             snapshotReceiver.RegisterEntity(entity.Id, playerVisual);
             if (cameraFollow != null && playerVisual != null)


### PR DESCRIPTION
## Summary
- target player's visual transform in `ClientInputSender`
- pass visual to input sender during client bootstrap

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b7b408218832187ed6bc76186306e