### PR TITLE
Snapshot vertical velocity view before updating

### DIFF
--- a/CodexTest/Assets/Scripts/Systems/JumpSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/JumpSystem.cs
@@ -3,6 +3,7 @@ using Game.Domain.Commands;
 using Game.Domain.ECS;
 using Game.Domain.Events;
 using Game.Infrastructure;
+using System.Linq;
 using UnityEngine;
 
 namespace Game.Systems
@@ -27,7 +28,8 @@ namespace Game.Systems
         public void Update(World world, float deltaTime)
         {
             _deltaTime = deltaTime;
-            foreach (var (entity, vel) in _world.View<VerticalVelocityComponent>())
+            var velocities = _world.View<VerticalVelocityComponent>().ToList();
+            foreach (var (entity, vel) in velocities)
             {
                 var velocity = vel;
                 if (_world.TryGetComponent(entity, out PositionComponent position))


### PR DESCRIPTION
## Summary
- Avoid modifying the world dictionary while iterating in `JumpSystem` by snapshotting the vertical velocity view to a list before processing
- Import `System.Linq` to enable the snapshot via `ToList`

## Testing
- `ls Assets/Tests` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b9884904c8321b52d31bab1ea9e5c