### PR TITLE
Add ping-based network latency logging

### DIFF
--- a/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
@@ -20,6 +20,7 @@ namespace Game.Infrastructure
         [SerializeField] private Transform playerVisual;
         [SerializeField] private CameraFollow cameraFollow;
         [SerializeField] private ClientSnapshotReceiver snapshotReceiver;
+        [SerializeField] private NetworkLatencyLogger latencyLogger;
 
         private NetworkManager networkManager;
         private bool playerInitialized;
@@ -29,6 +30,10 @@ namespace Game.Infrastructure
             networkManager = new NetworkManager();
             networkManager.StartClient(address, port);
             networkManager.OnData += OnDataReceived;
+            if (latencyLogger != null)
+            {
+                latencyLogger.Initialize(networkManager);
+            }
         }
 
         private void OnDataReceived(NetworkConnection connection, DataStreamReader stream)

--- a/CodexTest/Assets/Scripts/Infrastructure/NetworkLatencyLogger.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/NetworkLatencyLogger.cs
@@ -1,0 +1,68 @@
+using System;
+using Game.Networking;
+using Game.Networking.Messages;
+using Unity.Collections;
+using Unity.Networking.Transport;
+using UnityEngine;
+
+namespace Game.Infrastructure
+{
+    /// <summary>
+    /// Periodically sends ping messages and logs round-trip latency.
+    /// </summary>
+    public class NetworkLatencyLogger : MonoBehaviour
+    {
+        [SerializeField] private float pingInterval = 1f;
+        private NetworkManager _networkManager;
+        private float _timer;
+
+        /// <summary>
+        /// Injects the network manager and subscribes to data events.
+        /// </summary>
+        public void Initialize(NetworkManager manager)
+        {
+            _networkManager = manager;
+            _networkManager.OnData += OnDataReceived;
+        }
+
+        private void Update()
+        {
+            if (_networkManager == null || !_networkManager.IsConnected)
+                return;
+
+            _timer += Time.deltaTime;
+            if (_timer >= pingInterval)
+            {
+                _timer = 0f;
+                var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                var ping = new Ping(timestamp);
+                var payload = JsonUtility.ToJson(ping);
+                var message = new NetworkMessage(MessageType.Ping, payload);
+                _networkManager.SendMessage(message);
+            }
+        }
+
+        private void OnDataReceived(NetworkConnection connection, DataStreamReader stream)
+        {
+            using var bytes = new NativeArray<byte>(stream.Length, Allocator.Temp);
+            stream.ReadBytes(bytes);
+            var json = System.Text.Encoding.UTF8.GetString(bytes.ToArray());
+            var message = JsonUtility.FromJson<NetworkMessage>(json);
+            if (message.Type != MessageType.Ping)
+                return;
+
+            var ping = JsonUtility.FromJson<Ping>(message.Payload);
+            var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            var rtt = now - ping.Timestamp;
+            Debug.Log($"RTT: {rtt} ms");
+        }
+
+        private void OnDestroy()
+        {
+            if (_networkManager != null)
+            {
+                _networkManager.OnData -= OnDataReceived;
+            }
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Infrastructure/NetworkLatencyLogger.cs.meta
+++ b/CodexTest/Assets/Scripts/Infrastructure/NetworkLatencyLogger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03429167cb914ddebbea4fbb724bfc5b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
@@ -53,6 +53,12 @@ namespace Game.Infrastructure
                     _eventBus.Publish(validated);
                 }
             };
+
+            _handlers[MessageType.Ping] = (conn, payload) =>
+            {
+                var message = new NetworkMessage(MessageType.Ping, payload);
+                _networkManager.SendMessage(conn, message);
+            };
         }
 
         private void OnDataReceived(NetworkConnection connection, DataStreamReader stream)

--- a/CodexTest/Assets/Scripts/Networking/Messages/NetworkMessage.cs
+++ b/CodexTest/Assets/Scripts/Networking/Messages/NetworkMessage.cs
@@ -7,7 +7,8 @@ namespace Game.Networking.Messages
         MoveCommand = 1,
         PositionSnapshot = 2,
         JumpCommand = 3,
-        SpawnPlayer = 4
+        SpawnPlayer = 4,
+        Ping = 5
     }
 
     /// <summary>

--- a/CodexTest/Assets/Scripts/Networking/Messages/Ping.cs
+++ b/CodexTest/Assets/Scripts/Networking/Messages/Ping.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Game.Networking.Messages
+{
+    /// <summary>
+    /// Simple message used to measure round-trip time.
+    /// </summary>
+    [Serializable]
+    public struct Ping
+    {
+        public long Timestamp;
+
+        public Ping(long timestamp)
+        {
+            Timestamp = timestamp;
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Networking/Messages/Ping.cs.meta
+++ b/CodexTest/Assets/Scripts/Networking/Messages/Ping.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00847b1f62144b068a3fe776b42e4247
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add Ping network message type
- log round-trip time on the client via NetworkLatencyLogger
- echo ping messages on the server to measure latency

## Testing
- `ls CodexTest/Assets/Tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b9c4fffa08321896e60e9b875356d