### PR TITLE
Add ping display UI and latency event

### DIFF
--- a/CodexTest/Assets/ClientScene.unity
+++ b/CodexTest/Assets/ClientScene.unity
@@ -135,6 +135,7 @@ GameObject:
   - component: {fileID: 75909471}
   - component: {fileID: 75909470}
   - component: {fileID: 75909468}
+  - component: {fileID: 1800000000}
   m_Layer: 0
   m_Name: Client
   m_TagString: Untagged
@@ -231,6 +232,20 @@ MonoBehaviour:
   playerVisual: {fileID: 826165231}
   cameraFollow: {fileID: 1666591920}
   snapshotReceiver: {fileID: 75909470}
+  latencyLogger: {fileID: 1800000000}
+--- !u!114 &1800000000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 75909467}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03429167cb914ddebbea4fbb724bfc5b, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  pingInterval: 1
 --- !u!4 &75909473
 Transform:
   m_ObjectHideFlags: 0
@@ -600,6 +615,140 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1800000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1800000002}
+  - component: {fileID: 1800000003}
+  m_Layer: 5
+  m_Name: PingCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1800000002
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1800000001}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1800000011}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &1800000003
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1800000001}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!1 &1800000010
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1800000011}
+  - component: {fileID: 1800000012}
+  - component: {fileID: 1800000013}
+  - component: {fileID: 1800000014}
+  m_Layer: 5
+  m_Name: PingText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1800000011
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1800000010}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1800000002}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 10, y: -10}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &1800000012
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1800000010}
+  m_CullTransparentMesh: 1
+--- !u!114 &1800000013
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1800000010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_text: Ping: 0 ms
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+--- !u!114 &1800000014
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1800000010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbccdd79e51a4a3c9c2a33561ae19e12, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  pingText: {fileID: 1800000013}
+  latencyLogger: {fileID: 1800000000}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -607,3 +756,4 @@ SceneRoots:
   - {fileID: 1666591917}
   - {fileID: 75909473}
   - {fileID: 1753696182}
+  - {fileID: 1800000002}

--- a/CodexTest/Assets/Scripts/Infrastructure/NetworkLatencyLogger.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/NetworkLatencyLogger.cs
@@ -17,6 +17,11 @@ namespace Game.Infrastructure
         private float _timer;
 
         /// <summary>
+        /// Fired whenever a new round-trip time is measured.
+        /// </summary>
+        public event Action<long> OnPingUpdated;
+
+        /// <summary>
         /// Injects the network manager and subscribes to data events.
         /// </summary>
         public void Initialize(NetworkManager manager)
@@ -55,6 +60,7 @@ namespace Game.Infrastructure
             var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             var rtt = now - ping.Timestamp;
             Debug.Log($"RTT: {rtt} ms");
+            OnPingUpdated?.Invoke(rtt);
         }
 
         private void OnDestroy()

--- a/CodexTest/Assets/Scripts/Presentation/PingDisplay.cs
+++ b/CodexTest/Assets/Scripts/Presentation/PingDisplay.cs
@@ -1,0 +1,41 @@
+using Game.Infrastructure;
+using TMPro;
+using UnityEngine;
+
+namespace Game.Presentation
+{
+    /// <summary>
+    /// Displays the latest network ping value on a UI text element.
+    /// Presentation only; no gameplay logic.
+    /// </summary>
+    public class PingDisplay : MonoBehaviour
+    {
+        [SerializeField] private TMP_Text pingText;
+        [SerializeField] private NetworkLatencyLogger latencyLogger;
+
+        private void OnEnable()
+        {
+            if (latencyLogger != null)
+            {
+                latencyLogger.OnPingUpdated += HandlePingUpdated;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (latencyLogger != null)
+            {
+                latencyLogger.OnPingUpdated -= HandlePingUpdated;
+            }
+        }
+
+        private void HandlePingUpdated(long rtt)
+        {
+            if (pingText != null)
+            {
+                pingText.text = $"Ping: {rtt} ms";
+            }
+        }
+    }
+}
+

--- a/CodexTest/Assets/Scripts/Presentation/PingDisplay.cs.meta
+++ b/CodexTest/Assets/Scripts/Presentation/PingDisplay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cbccdd79e51a4a3c9c2a33561ae19e12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- emit round-trip latency through `OnPingUpdated`
- add `PingDisplay` MonoBehaviour to render latest ping
- wire `ClientScene` with canvas and text for displaying ping

## Testing
- `ls CodexTest/Assets/Tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b9e6bf4308321989fa0aa6832e1f0