### PR TITLE
Allow client server override

### DIFF
--- a/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
@@ -25,6 +25,35 @@ namespace Game.Infrastructure
         private NetworkManager networkManager;
         private bool playerInitialized;
 
+        private void Awake()
+        {
+            // Allow overriding address/port via command line or environment variables.
+            var args = System.Environment.GetCommandLineArgs();
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (args[i] == "-server" && i + 1 < args.Length)
+                {
+                    address = args[i + 1];
+                }
+                else if (args[i] == "-port" && i + 1 < args.Length && ushort.TryParse(args[i + 1], out var parsedPort))
+                {
+                    port = parsedPort;
+                }
+            }
+
+            var envAddress = System.Environment.GetEnvironmentVariable("SERVER_ADDRESS");
+            if (!string.IsNullOrWhiteSpace(envAddress))
+            {
+                address = envAddress;
+            }
+
+            var envPort = System.Environment.GetEnvironmentVariable("SERVER_PORT");
+            if (!string.IsNullOrWhiteSpace(envPort) && ushort.TryParse(envPort, out var envParsedPort))
+            {
+                port = envParsedPort;
+            }
+        }
+
         private void Start()
         {
             networkManager = new NetworkManager();

--- a/SetupGuide.md
+++ b/SetupGuide.md
@@ -68,7 +68,14 @@ Place the provided `.cs` files into their matching folders.
 3. On another machine, run the client scene and configure it to connect to that IP and port.
 4. Ensure any firewalls allow traffic on the chosen port.
 
-## 7. Project Overview
+## 7. Connecting over the Internet
+1. Make the server reachable from the Internet (configure port forwarding and firewalls so that port `7777` is open).
+2. Share the server's public IP address with remote testers.
+3. Run the client build with command line overrides: `MyGame.exe -server <public-ip> -port 7777`.
+   Alternatively, set environment variables `SERVER_ADDRESS` and `SERVER_PORT` before launching the client.
+4. The `NetworkLatencyLogger` component shows ping, allowing comparisons between different locations.
+
+## 8. Project Overview
 - **Domain/ECS** – core ECS types (`Entity`, `World`, `ISystem`, `IComponent`).
 - **Components** – data-only components such as `PositionComponent`.
 - **Systems** – server logic like `MovementSystem` and `JumpSystem` responding to events.


### PR DESCRIPTION
## Summary
- allow client to override server address/port via command line args or environment variables
- document how to connect to a remote server and test latency

## Testing
- `unity-editor -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ba7417e908321a33ddbe2ca0f6c49