### PR TITLE
Use port 80 as default network port

### DIFF
--- a/CodexTest/Assets/ClientScene.unity
+++ b/CodexTest/Assets/ClientScene.unity
@@ -227,7 +227,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   address: 127.0.0.1
-  port: 7777
+  port: 80
   inputSender: {fileID: 75909471}
   playerVisual: {fileID: 826165231}
   cameraFollow: {fileID: 1666591920}

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
@@ -15,7 +15,7 @@ namespace Game.Infrastructure
     public class ClientBootstrap : MonoBehaviour
     {
         [SerializeField] private string address = "127.0.0.1";
-        [SerializeField] private ushort port = 7777;
+        [SerializeField] private ushort port = 80;
         [SerializeField] private ClientInputSender inputSender;
         [SerializeField] private Transform playerVisual;
         [SerializeField] private CameraFollow cameraFollow;

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
@@ -18,7 +18,7 @@ namespace Game.Infrastructure
     /// </summary>
     public class ServerBootstrap : MonoBehaviour
     {
-        [SerializeField] private ushort port = 7777;
+        [SerializeField] private ushort port = 80;
 
         private World world;
         private EventBus eventBus;

--- a/CodexTest/Assets/ServerScene.unity
+++ b/CodexTest/Assets/ServerScene.unity
@@ -151,7 +151,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e087988331ec72345b9d16622a067626, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  port: 7777
+  port: 80
 --- !u!4 &683224130
 Transform:
   m_ObjectHideFlags: 0

--- a/SetupGuide.md
+++ b/SetupGuide.md
@@ -69,9 +69,9 @@ Place the provided `.cs` files into their matching folders.
 4. Ensure any firewalls allow traffic on the chosen port.
 
 ## 7. Connecting over the Internet
-1. Make the server reachable from the Internet (configure port forwarding and firewalls so that port `7777` is open).
+1. Make the server reachable from the Internet (configure port forwarding and firewalls so that port `80` is open).
 2. Share the server's public IP address with remote testers.
-3. Run the client build with command line overrides: `MyGame.exe -server <public-ip> -port 7777`.
+3. Run the client build with command line overrides: `MyGame.exe -server <public-ip> -port 80`.
    Alternatively, set environment variables `SERVER_ADDRESS` and `SERVER_PORT` before launching the client.
 4. The `NetworkLatencyLogger` component shows ping, allowing comparisons between different locations.
 


### PR DESCRIPTION
## Summary
- switch server and client bootstraps to port 80
- update sample scenes and setup guide for port 80

## Testing
- `rg -n 7777 -g '*.cs' -g '*.unity' -g '*.md'`
- `rg -n 'port = 80' -g '*.cs'`
- `rg -n 'port: 80' -g '*.unity'`


------
https://chatgpt.com/codex/tasks/task_e_689bb1ce23448321a622e78661b21457