### PR TITLE
Fix mouse variable scope conflict in CameraController

### DIFF
--- a/CodexTest/Assets/Scripts/Presentation/CameraController.cs
+++ b/CodexTest/Assets/Scripts/Presentation/CameraController.cs
@@ -41,10 +41,10 @@ namespace Game.Presentation
 
             if (Input.GetMouseButton(2))
             {
-                Vector3 mouse = Input.mousePosition;
-                float deltaX = mouse.x - previousMousePosition.x;
+                Vector3 currentMouse = Input.mousePosition;
+                float deltaX = currentMouse.x - previousMousePosition.x;
                 _yaw += deltaX * orbitSensitivity;
-                previousMousePosition = mouse;
+                previousMousePosition = currentMouse;
             }
 
             var rotation = Quaternion.Euler(0f, _yaw, 0f) * _initialRotation;


### PR DESCRIPTION
## Summary
- Rename inner mouse variable in `CameraController` to avoid shadowing and resolve CS0136 compile error.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*


------
https://chatgpt.com/codex/tasks/task_e_689cd7379e2c8321afd801ea7a434516