### PR TITLE
Fix camera initial offset

### DIFF
--- a/CodexTest/Assets/Scripts/Presentation/CameraController.cs
+++ b/CodexTest/Assets/Scripts/Presentation/CameraController.cs
@@ -28,6 +28,11 @@ namespace Game.Presentation
         {
             baseOffset = offset;
             _initialRotation = transform.rotation;
+
+            if (target != null)
+            {
+                SetTarget(target);
+            }
         }
 
         private void LateUpdate()
@@ -83,6 +88,17 @@ namespace Game.Presentation
         public void SetTarget(Transform newTarget)
         {
             target = newTarget;
+            if (target == null)
+            {
+                return;
+            }
+
+            targetDragOffset = Vector3.zero;
+            dragOffset = Vector3.zero;
+
+            var rotation = Quaternion.Euler(0f, _yaw, 0f) * _initialRotation;
+            var desired = target.position + rotation * baseOffset;
+            transform.SetPositionAndRotation(desired, rotation);
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure camera snaps to player immediately when target assigned
- reinitialize drag offsets when switching target

## Testing
- `find Assets -path "*Tests*" -print`
- `mcs Assets/Scripts/Presentation/CameraController.cs >/tmp/compile.log && cat /tmp/compile.log` *(fails: command not found: mcs)*

------
https://chatgpt.com/codex/tasks/task_e_689cda4c75188321ad242d0a42a4dca2