### PR TITLE
Improve camera orbit and screen-relative movement

### DIFF
--- a/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
@@ -81,7 +81,14 @@ namespace Game.Infrastructure
             {
                 if (_input != Vector2.zero)
                 {
-                    var direction = new Vector3(_input.x, 0f, _input.y);
+                    Transform cam = Camera.main.transform;
+                    Vector3 camForward = cam.forward;
+                    camForward.y = 0f;
+                    camForward.Normalize();
+                    Vector3 camRight = cam.right;
+                    camRight.y = 0f;
+                    camRight.Normalize();
+                    var direction = camRight * _input.x + camForward * _input.y;
 
                     // Client-side prediction for horizontal movement.
                     _target.Translate(direction.normalized * moveSpeed * _fixedDeltaTime, Space.World);

--- a/CodexTest/Assets/Scripts/Presentation/CameraController.cs
+++ b/CodexTest/Assets/Scripts/Presentation/CameraController.cs
@@ -68,6 +68,11 @@ namespace Game.Presentation
 
             Vector3 hoverOffset = (normalized.x * right + normalized.y * forward) * hoverSensitivity;
 
+            if (Input.GetMouseButton(2))
+            {
+                hoverOffset = Vector3.zero;
+            }
+
             if (Input.GetMouseButton(1))
             {
                 Vector3 drag = (normalized.x * right + normalized.y * forward) * dragSensitivity;
@@ -80,9 +85,7 @@ namespace Game.Presentation
 
             dragOffset = Vector3.Lerp(dragOffset, targetDragOffset, followSpeed * Time.deltaTime);
 
-            var desired = target.position + yawRotation * baseOffset + hoverOffset + dragOffset; // rotate offset only around Y
-            transform.position = Vector3.Lerp(transform.position, desired, followSpeed * Time.deltaTime);
-
+            transform.position = target.position + yawRotation * baseOffset + hoverOffset + dragOffset;
             transform.rotation = rotation;
         }
 


### PR DESCRIPTION
## Summary
- keep camera pivot on player while rotating, remove smoothing for snappier orbit
- drive player movement from camera orientation so WASD follows screen directions

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ce5fa365083218ebd0cf575955aa8