### PR TITLE
feat: implement stamina, hunger, and walking mode

### DIFF
--- a/CodexTest/Assets/Scripts/Components/HungerComponent.cs
+++ b/CodexTest/Assets/Scripts/Components/HungerComponent.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Game.Components
+{
+    /// <summary>
+    /// Represents hunger decreasing over time.
+    /// </summary>
+    [Serializable]
+    public struct HungerComponent
+    {
+        public float Current;
+        public float Max;
+        /// <summary>
+        /// Hunger drained per second.
+        /// </summary>
+        public float DrainPerSecond;
+    }
+}

--- a/CodexTest/Assets/Scripts/Components/HungerComponent.cs.meta
+++ b/CodexTest/Assets/Scripts/Components/HungerComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ac331f6abc94292973832fb45d40bf1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Scripts/Components/MovementSpeedComponent.cs
+++ b/CodexTest/Assets/Scripts/Components/MovementSpeedComponent.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Game.Components
+{
+    /// <summary>
+    /// Holds walk and run speeds for an entity.
+    /// </summary>
+    [Serializable]
+    public struct MovementSpeedComponent
+    {
+        public float WalkSpeed;
+        public float RunSpeed;
+    }
+}

--- a/CodexTest/Assets/Scripts/Components/MovementSpeedComponent.cs.meta
+++ b/CodexTest/Assets/Scripts/Components/MovementSpeedComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ac2366e5b5b49618885fb86bab32639
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Scripts/Components/MovementStateComponent.cs
+++ b/CodexTest/Assets/Scripts/Components/MovementStateComponent.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Game.Components
+{
+    /// <summary>
+    /// Stores current movement state such as running or walking.
+    /// </summary>
+    [Serializable]
+    public struct MovementStateComponent
+    {
+        public bool IsRunning;
+    }
+}

--- a/CodexTest/Assets/Scripts/Components/MovementStateComponent.cs.meta
+++ b/CodexTest/Assets/Scripts/Components/MovementStateComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 063966ed2df64c33a29cc4c101a80755
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Scripts/Components/StaminaComponent.cs
+++ b/CodexTest/Assets/Scripts/Components/StaminaComponent.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Game.Components
+{
+    /// <summary>
+    /// Represents stamina used for sprinting.
+    /// </summary>
+    [Serializable]
+    public struct StaminaComponent
+    {
+        public float Current;
+        public float Max;
+        /// <summary>
+        /// Stamina consumed per second while running.
+        /// </summary>
+        public float DrainPerSecond;
+        /// <summary>
+        /// Stamina regenerated per second when not running and not starving.
+        /// </summary>
+        public float RegenPerSecond;
+    }
+}

--- a/CodexTest/Assets/Scripts/Components/StaminaComponent.cs.meta
+++ b/CodexTest/Assets/Scripts/Components/StaminaComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 62112bc7c02447b19003a331ea0cf377
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Scripts/Domain/Commands/MoveCommand.cs
+++ b/CodexTest/Assets/Scripts/Domain/Commands/MoveCommand.cs
@@ -18,22 +18,28 @@ namespace Game.Domain.Commands
         /// Movement speed in units per second.
         /// </summary>
         public float Speed;
+        /// <summary>
+        /// True if the player intends to run.
+        /// </summary>
+        public bool IsRunning;
         public int ClientId;
 
-        public MoveCommand(Entity entity, Vector3 direction, float speed)
+        public MoveCommand(Entity entity, Vector3 direction, float speed, bool isRunning)
         {
             Entity = entity;
             Direction = direction;
             Speed = speed;
+            IsRunning = isRunning;
             ClientId = 0;
         }
 
-        public MoveCommand(int clientId, Entity entity, Vector3 direction, float speed)
+        public MoveCommand(int clientId, Entity entity, Vector3 direction, float speed, bool isRunning)
         {
             ClientId = clientId;
             Entity = entity;
             Direction = direction;
             Speed = speed;
+            IsRunning = isRunning;
         }
     }
 }

--- a/CodexTest/Assets/Scripts/Domain/Events/HungerChangedEvent.cs
+++ b/CodexTest/Assets/Scripts/Domain/Events/HungerChangedEvent.cs
@@ -1,0 +1,21 @@
+using Game.Domain.ECS;
+
+namespace Game.Domain.Events
+{
+    /// <summary>
+    /// Raised when an entity's hunger changes.
+    /// </summary>
+    public struct HungerChangedEvent
+    {
+        public Entity Entity;
+        public float Current;
+        public float Max;
+
+        public HungerChangedEvent(Entity entity, float current, float max)
+        {
+            Entity = entity;
+            Current = current;
+            Max = max;
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Domain/Events/HungerChangedEvent.cs.meta
+++ b/CodexTest/Assets/Scripts/Domain/Events/HungerChangedEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b51b721c394d449fa568e89d8177a8a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Scripts/Domain/Events/StaminaChangedEvent.cs
+++ b/CodexTest/Assets/Scripts/Domain/Events/StaminaChangedEvent.cs
@@ -1,0 +1,21 @@
+using Game.Domain.ECS;
+
+namespace Game.Domain.Events
+{
+    /// <summary>
+    /// Raised when an entity's stamina changes.
+    /// </summary>
+    public struct StaminaChangedEvent
+    {
+        public Entity Entity;
+        public float Current;
+        public float Max;
+
+        public StaminaChangedEvent(Entity entity, float current, float max)
+        {
+            Entity = entity;
+            Current = current;
+            Max = max;
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Domain/Events/StaminaChangedEvent.cs.meta
+++ b/CodexTest/Assets/Scripts/Domain/Events/StaminaChangedEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7703645282e4ec69731e40d180517f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
@@ -14,7 +14,8 @@ namespace Game.Infrastructure
     public class ClientInputSender : MonoBehaviour
     {
         private NetworkManager networkManager;
-        [SerializeField] private float moveSpeed = 5f;
+        [SerializeField] private float walkSpeed = 2f;
+        [SerializeField] private float runSpeed = 5f;
         [SerializeField] private float jumpForce = 5f;
         [SerializeField] private float gravity = -9.81f;
         private Vector2 _input;
@@ -90,10 +91,13 @@ namespace Game.Infrastructure
                     camRight.Normalize();
                     var direction = camRight * _input.x + camForward * _input.y;
 
-                    // Client-side prediction for horizontal movement.
-                    _target.Translate(direction.normalized * moveSpeed * _fixedDeltaTime, Space.World);
+                    bool isRunning = !Mouse.current.rightButton.isPressed;
+                    float speed = isRunning ? runSpeed : walkSpeed;
 
-                    var command = new MoveCommand(PlayerEntity, direction, moveSpeed);
+                    // Client-side prediction for horizontal movement.
+                    _target.Translate(direction.normalized * speed * _fixedDeltaTime, Space.World);
+
+                    var command = new MoveCommand(PlayerEntity, direction, speed, isRunning);
                     var payload = JsonUtility.ToJson(command);
                     var message = new NetworkMessage(MessageType.MoveCommand, payload);
                     networkManager.SendMessage(message);

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
@@ -39,7 +39,7 @@ namespace Game.Infrastructure
                 var cmd = JsonUtility.FromJson<MoveCommand>(payload);
                 if (!cmd.Equals(default(MoveCommand)) && _connectionToEntity.TryGetValue(conn, out var entity))
                 {
-                    var validated = new MoveCommand(entity, cmd.Direction, cmd.Speed);
+                    var validated = new MoveCommand(entity, cmd.Direction, cmd.Speed, cmd.IsRunning);
                     _eventBus.Publish(validated);
                 }
             };

--- a/CodexTest/Assets/Scripts/Systems/MovementSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/MovementSystem.cs
@@ -3,6 +3,7 @@ using Game.Domain.Commands;
 using Game.Domain.ECS;
 using Game.Domain.Events;
 using Game.Infrastructure;
+using UnityEngine;
 
 namespace Game.Systems
 {
@@ -31,12 +32,41 @@ namespace Game.Systems
 
         private void OnMoveCommand(MoveCommand command)
         {
-            if (_world.TryGetComponent(command.Entity, out PositionComponent position))
+            if (!_world.TryGetComponent(command.Entity, out PositionComponent position))
+                return;
+
+            // Determine movement mode based on stamina and desired state.
+            float speed = command.Speed;
+            bool isRunning = command.IsRunning;
+
+            if (_world.TryGetComponent(command.Entity, out StaminaComponent stamina))
             {
-                position.Value += command.Direction.normalized * command.Speed * _fixedDeltaTime;
-                _world.SetComponent(command.Entity, position);
-                _eventBus.Publish(new PositionChangedEvent(command.Entity, position.Value));
+                if (isRunning && stamina.Current <= 0f)
+                {
+                    isRunning = false;
+                }
+
+                // Use configured speeds instead of trusting client supplied speed.
+                if (_world.TryGetComponent(command.Entity, out MovementSpeedComponent moveSpeed))
+                {
+                    speed = isRunning ? moveSpeed.RunSpeed : moveSpeed.WalkSpeed;
+                }
             }
+
+            // Physics-based movement with simple collision check.
+            Vector3 direction = command.Direction.normalized;
+            float distance = speed * _fixedDeltaTime;
+            Vector3 target = position.Value + direction * distance;
+            if (!Physics.CheckSphere(target, 0.4f))
+            {
+                position.Value = target;
+            }
+            _world.SetComponent(command.Entity, position);
+            _eventBus.Publish(new PositionChangedEvent(command.Entity, position.Value));
+
+            // Update movement state component
+            var state = new MovementStateComponent { IsRunning = isRunning };
+            _world.SetComponent(command.Entity, state);
         }
     }
 }

--- a/CodexTest/Assets/Scripts/Systems/SurvivalSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/SurvivalSystem.cs
@@ -1,0 +1,62 @@
+using Game.Components;
+using Game.Domain.ECS;
+using Game.Domain.Events;
+using Game.Infrastructure;
+using System.Linq;
+using UnityEngine;
+
+namespace Game.Systems
+{
+    /// <summary>
+    /// Handles stamina regeneration and hunger depletion.
+    /// </summary>
+    public class SurvivalSystem : ISystem
+    {
+        private readonly World _world;
+        private readonly EventBus _eventBus;
+        private float _fixedDeltaTime;
+
+        public SurvivalSystem(World world, EventBus eventBus)
+        {
+            _world = world;
+            _eventBus = eventBus;
+        }
+
+        public void Update(World world, float deltaTime)
+        {
+            _fixedDeltaTime = deltaTime;
+
+            var staminaEntities = _world.View<StaminaComponent>().ToList();
+            foreach (var (entity, stamina) in staminaEntities)
+            {
+                var st = stamina;
+                bool isRunning = false;
+                if (_world.TryGetComponent(entity, out MovementStateComponent state))
+                {
+                    isRunning = state.IsRunning;
+                }
+
+                if (isRunning && st.Current > 0f)
+                {
+                    st.Current = Mathf.Max(0f, st.Current - st.DrainPerSecond * _fixedDeltaTime);
+                }
+                else if (_world.TryGetComponent(entity, out HungerComponent hunger) && hunger.Current > 0f)
+                {
+                    st.Current = Mathf.Min(st.Max, st.Current + st.RegenPerSecond * _fixedDeltaTime);
+                }
+
+                _world.SetComponent(entity, st);
+                _eventBus.Publish(new StaminaChangedEvent(entity, st.Current, st.Max));
+            }
+
+            var hungerEntities = _world.View<HungerComponent>().ToList();
+            foreach (var (entity, hunger) in hungerEntities)
+            {
+                var h = hunger;
+                h.Current = Mathf.Max(0f, h.Current - h.DrainPerSecond * _fixedDeltaTime);
+                _world.SetComponent(entity, h);
+                _eventBus.Publish(new HungerChangedEvent(entity, h.Current, h.Max));
+            }
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Systems/SurvivalSystem.cs.meta
+++ b/CodexTest/Assets/Scripts/Systems/SurvivalSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b24a25dbba3e4e758f81af8118557dad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add stamina, hunger, and movement speed components
- support run/walk modes with right-click walking
- introduce survival system and physics-aware movement handling

## Testing
- `unity -batchmode -projectPath CodexTest -runTests -testResults results.xml -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cf0b8222483219abe8452ddef5762