### PR TITLE
Add survival stat replication and UI bars

### DIFF
--- a/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
@@ -20,9 +20,12 @@ namespace Game.Infrastructure
         [SerializeField] private Transform playerVisual;
         [SerializeField] private CameraController cameraController;
         [SerializeField] private ClientSnapshotReceiver snapshotReceiver;
+        [SerializeField] private StatsSnapshotReceiver statsReceiver;
+        [SerializeField] private SurvivalUI survivalUI;
         [SerializeField] private NetworkLatencyLogger latencyLogger;
 
         private NetworkManager networkManager;
+        private EventBus eventBus;
         private bool playerInitialized;
 
         private void Awake()
@@ -56,6 +59,7 @@ namespace Game.Infrastructure
 
         private void Start()
         {
+            eventBus = new EventBus();
             networkManager = new NetworkManager();
             networkManager.StartClient(address, port);
             networkManager.OnData += OnDataReceived;
@@ -82,6 +86,14 @@ namespace Game.Infrastructure
             }
             snapshotReceiver.Initialize(networkManager, playerVisual);
             snapshotReceiver.RegisterEntity(entity.Id, playerVisual);
+            if (statsReceiver != null)
+            {
+                statsReceiver.Initialize(networkManager, eventBus, entity);
+            }
+            if (survivalUI != null)
+            {
+                survivalUI.Initialize(eventBus);
+            }
             if (cameraController != null && playerVisual != null)
             {
                 cameraController.SetTarget(playerVisual);

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
@@ -25,6 +25,8 @@ namespace Game.Infrastructure
         private MovementSystem movementSystem;
         private ReplicationSystem replicationSystem;
         private JumpSystem jumpSystem;
+        private SurvivalSystem survivalSystem;
+        private SurvivalReplicationSystem survivalReplicationSystem;
         private ServerCommandDispatcher dispatcher;
         private CommandHandler commandHandler;
         private Dictionary<NetworkConnection, Entity> connectionToEntity;
@@ -46,6 +48,8 @@ namespace Game.Infrastructure
             movementSystem = new MovementSystem(world, eventBus);
             replicationSystem = new ReplicationSystem(networkManager, eventBus);
             jumpSystem = new JumpSystem(world, eventBus);
+            survivalSystem = new SurvivalSystem(world, eventBus);
+            survivalReplicationSystem = new SurvivalReplicationSystem(networkManager, eventBus);
             commandHandler = new CommandHandler(eventBus);
             fixedDeltaTime = 1f / Constants.ServerTickRate;
             _initialized = true;
@@ -55,7 +59,13 @@ namespace Game.Infrastructure
         {
             var entity = world.CreateEntity();
             world.AddComponent(entity, new PositionComponent { Value = Vector3.zero });
+            world.AddComponent(entity, new MovementSpeedComponent { WalkSpeed = 2f, RunSpeed = 4f });
+            world.AddComponent(entity, new StaminaComponent { Current = 100f, Max = 100f, DrainPerSecond = 10f, RegenPerSecond = 5f });
+            world.AddComponent(entity, new HungerComponent { Current = 100f, Max = 100f, DrainPerSecond = 1f });
+            world.AddComponent(entity, new MovementStateComponent { IsRunning = false });
             eventBus.Publish(new PositionChangedEvent(entity, Vector3.zero));
+            eventBus.Publish(new StaminaChangedEvent(entity, 100f, 100f));
+            eventBus.Publish(new HungerChangedEvent(entity, 100f, 100f));
             connectionToEntity[connection] = entity;
 
             var spawn = new SpawnPlayer(entity);
@@ -83,6 +93,8 @@ namespace Game.Infrastructure
                 movementSystem.Update(world, fixedDeltaTime);
                 replicationSystem.Update(world, fixedDeltaTime);
                 jumpSystem.Update(world, fixedDeltaTime);
+                survivalSystem.Update(world, fixedDeltaTime);
+                survivalReplicationSystem.Update(world, fixedDeltaTime);
                 tickAccumulator -= fixedDeltaTime;
             }
         }

--- a/CodexTest/Assets/Scripts/Infrastructure/StatsSnapshotReceiver.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/StatsSnapshotReceiver.cs
@@ -1,0 +1,66 @@
+using System.Text;
+using Game.Domain.Events;
+using Game.Domain.ECS;
+using Game.Infrastructure;
+using Game.Networking;
+using Game.Networking.Messages;
+using Unity.Collections;
+using Unity.Networking.Transport;
+using UnityEngine;
+
+namespace Game.Infrastructure
+{
+    /// <summary>
+    /// Receives survival stat snapshots from the server and publishes events for the local player.
+    /// </summary>
+    public class StatsSnapshotReceiver : MonoBehaviour
+    {
+        private NetworkManager _networkManager;
+        private EventBus _eventBus;
+        private int _playerEntityId;
+
+        public void Initialize(NetworkManager manager, EventBus eventBus, Entity player)
+        {
+            _networkManager = manager;
+            _eventBus = eventBus;
+            _playerEntityId = player.Id;
+            _networkManager.OnData += OnDataReceived;
+        }
+
+        private void OnDataReceived(NetworkConnection connection, DataStreamReader stream)
+        {
+            using var bytes = new NativeArray<byte>(stream.Length, Allocator.Temp);
+            stream.ReadBytes(bytes);
+            var json = Encoding.UTF8.GetString(bytes.ToArray());
+            var message = JsonUtility.FromJson<NetworkMessage>(json);
+
+            switch (message.Type)
+            {
+                case MessageType.StaminaSnapshot:
+                    var stamina = JsonUtility.FromJson<StaminaSnapshot>(message.Payload);
+                    if (stamina.EntityId == _playerEntityId)
+                    {
+                        _eventBus.Publish(new StaminaChangedEvent(new Entity(stamina.EntityId), stamina.Current, stamina.Max));
+                    }
+                    break;
+                case MessageType.HungerSnapshot:
+                    var hunger = JsonUtility.FromJson<HungerSnapshot>(message.Payload);
+                    if (hunger.EntityId == _playerEntityId)
+                    {
+                        _eventBus.Publish(new HungerChangedEvent(new Entity(hunger.EntityId), hunger.Current, hunger.Max));
+                    }
+                    break;
+                default:
+                    return;
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (_networkManager != null)
+            {
+                _networkManager.OnData -= OnDataReceived;
+            }
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Infrastructure/StatsSnapshotReceiver.cs.meta
+++ b/CodexTest/Assets/Scripts/Infrastructure/StatsSnapshotReceiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 64117a6e370e4cd28303262b416166cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Scripts/Networking/Messages/HungerSnapshot.cs
+++ b/CodexTest/Assets/Scripts/Networking/Messages/HungerSnapshot.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Game.Networking.Messages
+{
+    /// <summary>
+    /// Snapshot of hunger state for an entity.
+    /// </summary>
+    [Serializable]
+    public struct HungerSnapshot
+    {
+        public int EntityId;
+        public float Current;
+        public float Max;
+
+        public HungerSnapshot(int entityId, float current, float max)
+        {
+            EntityId = entityId;
+            Current = current;
+            Max = max;
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Networking/Messages/HungerSnapshot.cs.meta
+++ b/CodexTest/Assets/Scripts/Networking/Messages/HungerSnapshot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8de7404d6f944eb0a45f65da5809fa18
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Scripts/Networking/Messages/NetworkMessage.cs
+++ b/CodexTest/Assets/Scripts/Networking/Messages/NetworkMessage.cs
@@ -8,7 +8,9 @@ namespace Game.Networking.Messages
         PositionSnapshot = 2,
         JumpCommand = 3,
         SpawnPlayer = 4,
-        Ping = 5
+        Ping = 5,
+        HungerSnapshot = 6,
+        StaminaSnapshot = 7
     }
 
     /// <summary>

--- a/CodexTest/Assets/Scripts/Networking/Messages/StaminaSnapshot.cs
+++ b/CodexTest/Assets/Scripts/Networking/Messages/StaminaSnapshot.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Game.Networking.Messages
+{
+    /// <summary>
+    /// Snapshot of stamina state for an entity.
+    /// </summary>
+    [Serializable]
+    public struct StaminaSnapshot
+    {
+        public int EntityId;
+        public float Current;
+        public float Max;
+
+        public StaminaSnapshot(int entityId, float current, float max)
+        {
+            EntityId = entityId;
+            Current = current;
+            Max = max;
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Networking/Messages/StaminaSnapshot.cs.meta
+++ b/CodexTest/Assets/Scripts/Networking/Messages/StaminaSnapshot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c238c48399984b64b05b60b2d7cab496
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Scripts/Presentation/SurvivalUI.cs
+++ b/CodexTest/Assets/Scripts/Presentation/SurvivalUI.cs
@@ -1,0 +1,50 @@
+using Game.Domain.Events;
+using Game.Infrastructure;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Game.Presentation
+{
+    /// <summary>
+    /// Displays hunger and stamina bars for the local player.
+    /// </summary>
+    public class SurvivalUI : MonoBehaviour
+    {
+        [SerializeField] private Slider hungerBar;
+        [SerializeField] private Slider staminaBar;
+
+        private EventBus _eventBus;
+
+        public void Initialize(EventBus eventBus)
+        {
+            _eventBus = eventBus;
+            _eventBus.Subscribe<HungerChangedEvent>(OnHungerChanged);
+            _eventBus.Subscribe<StaminaChangedEvent>(OnStaminaChanged);
+        }
+
+        private void OnHungerChanged(HungerChangedEvent evt)
+        {
+            if (hungerBar != null)
+            {
+                hungerBar.value = evt.Current / evt.Max;
+            }
+        }
+
+        private void OnStaminaChanged(StaminaChangedEvent evt)
+        {
+            if (staminaBar != null)
+            {
+                staminaBar.value = evt.Current / evt.Max;
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (_eventBus != null)
+            {
+                _eventBus.Unsubscribe<HungerChangedEvent>(OnHungerChanged);
+                _eventBus.Unsubscribe<StaminaChangedEvent>(OnStaminaChanged);
+            }
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Presentation/SurvivalUI.cs.meta
+++ b/CodexTest/Assets/Scripts/Presentation/SurvivalUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30175cfa7abc44788eededc9e25d2d51
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Scripts/Systems/SurvivalReplicationSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/SurvivalReplicationSystem.cs
@@ -1,0 +1,47 @@
+using Game.Domain.ECS;
+using Game.Domain.Events;
+using Game.Networking;
+using Game.Networking.Messages;
+using Game.Infrastructure;
+using UnityEngine;
+
+namespace Game.Systems
+{
+    /// <summary>
+    /// Replicates survival stats (stamina and hunger) to clients.
+    /// </summary>
+    public class SurvivalReplicationSystem : ISystem
+    {
+        private readonly NetworkManager _networkManager;
+        private readonly EventBus _eventBus;
+
+        public SurvivalReplicationSystem(NetworkManager networkManager, EventBus eventBus)
+        {
+            _networkManager = networkManager;
+            _eventBus = eventBus;
+            _eventBus.Subscribe<StaminaChangedEvent>(OnStaminaChanged);
+            _eventBus.Subscribe<HungerChangedEvent>(OnHungerChanged);
+        }
+
+        public void Update(World world, float deltaTime)
+        {
+            // Replication is event-driven; nothing per-frame.
+        }
+
+        private void OnStaminaChanged(StaminaChangedEvent evt)
+        {
+            var snapshot = new StaminaSnapshot(evt.Entity.Id, evt.Current, evt.Max);
+            var payload = JsonUtility.ToJson(snapshot);
+            var message = new NetworkMessage(MessageType.StaminaSnapshot, payload);
+            _networkManager.SendMessage(message);
+        }
+
+        private void OnHungerChanged(HungerChangedEvent evt)
+        {
+            var snapshot = new HungerSnapshot(evt.Entity.Id, evt.Current, evt.Max);
+            var payload = JsonUtility.ToJson(snapshot);
+            var message = new NetworkMessage(MessageType.HungerSnapshot, payload);
+            _networkManager.SendMessage(message);
+        }
+    }
+}

--- a/CodexTest/Assets/Scripts/Systems/SurvivalReplicationSystem.cs.meta
+++ b/CodexTest/Assets/Scripts/Systems/SurvivalReplicationSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 026cf57aad844d1d9b0b1f22a78686da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/SetupGuide.md
+++ b/SetupGuide.md
@@ -38,6 +38,8 @@ Place the provided `.cs` files into their matching folders.
    - `MovementSystem`
    - `JumpSystem`
    - `ReplicationSystem`
+   - `SurvivalSystem`
+   - `SurvivalReplicationSystem`
 4. Open **File → Build Settings** and enable **Dedicated Server/Server Build** to produce a headless executable. (Leave this unchecked for client builds.)
 
 ## 4. Client Scene
@@ -46,6 +48,8 @@ Place the provided `.cs` files into their matching folders.
 3. `ClientBootstrap` references:
    - `ClientInputSender`
    - `ClientSnapshotReceiver`
+   - `StatsSnapshotReceiver`
+   - `SurvivalUI` (assign hunger & stamina `Slider` UI elements anchored top‑left)
    - a player visual `Transform` used for rendering
    - `CameraFollow` on the main camera for top‑down tracking
 4. Add a `PlayerInput` component:
@@ -83,4 +87,4 @@ Place the provided `.cs` files into their matching folders.
 - **Infrastructure** – glue code (`EventBus`, `ClientInputSender`, `ServerCommandDispatcher`, `ClientBootstrap`, `ServerBootstrap`).
 - **Presentation** – visuals and camera scripts (`CameraFollow`).
 
-This setup yields a clean, event-driven, server‑authoritative ECS base where a player entity moves with WASD, the server replicates the position, and the client camera follows from a top‑down perspective.
+This setup yields a clean, event-driven, server‑authoritative ECS base where a player entity moves with WASD, the server replicates the position and survival stats, and the client camera follows from a top‑down perspective while displaying hunger and stamina bars.


### PR DESCRIPTION
## Summary
- send hunger and stamina updates from the server and replicate them to clients
- receive survival stat snapshots on the client and display them using new progress bars
- document server and client setup for the survival systems

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d8506d5688321bef2794a79de9fc2