### PR TITLE
Sync client movement speed with server

### DIFF
--- a/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
@@ -82,7 +82,7 @@ namespace Game.Infrastructure
             var entity = new Entity(spawn.EntityId);
             if (inputSender != null)
             {
-                inputSender.Initialize(networkManager, entity, playerVisual);
+                inputSender.Initialize(networkManager, entity, playerVisual, spawn.WalkSpeed, spawn.RunSpeed);
             }
             snapshotReceiver.Initialize(networkManager, playerVisual);
             snapshotReceiver.RegisterEntity(entity.Id, playerVisual);

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
@@ -14,8 +14,8 @@ namespace Game.Infrastructure
     public class ClientInputSender : MonoBehaviour
     {
         private NetworkManager networkManager;
-        [SerializeField] private float walkSpeed = 2f;
-        [SerializeField] private float runSpeed = 4f;
+        private float walkSpeed;
+        private float runSpeed;
         [SerializeField] private float jumpForce = 5f;
         [SerializeField] private float gravity = -9.81f;
         private Vector2 _input;
@@ -28,12 +28,14 @@ namespace Game.Infrastructure
         /// <summary>
         /// Injects dependencies from ClientBootstrap.
         /// </summary>
-        public void Initialize(NetworkManager manager, Entity playerEntity, Transform target)
+        public void Initialize(NetworkManager manager, Entity playerEntity, Transform target, float walkSpeed, float runSpeed)
         {
             networkManager = manager;
             PlayerEntity = playerEntity;
             _target = target;
             _fixedDeltaTime = 1f / Constants.ServerTickRate;
+            this.walkSpeed = walkSpeed;
+            this.runSpeed = runSpeed;
         }
 
         /// <summary>

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
@@ -64,7 +64,8 @@ namespace Game.Infrastructure
         {
             var entity = world.CreateEntity();
             world.AddComponent(entity, new PositionComponent { Value = Vector3.zero });
-            world.AddComponent(entity, new MovementSpeedComponent { WalkSpeed = 2f, RunSpeed = 4f });
+            var speedComponent = new MovementSpeedComponent { WalkSpeed = 2f, RunSpeed = 4f };
+            world.AddComponent(entity, speedComponent);
             world.AddComponent(entity, new StaminaComponent
             {
                 Current = survivalConfig.MaxStamina,
@@ -84,7 +85,7 @@ namespace Game.Infrastructure
             eventBus.Publish(new HungerChangedEvent(entity, survivalConfig.MaxHunger, survivalConfig.MaxHunger));
             connectionToEntity[connection] = entity;
 
-            var spawn = new SpawnPlayer(entity);
+            var spawn = new SpawnPlayer(entity, speedComponent.WalkSpeed, speedComponent.RunSpeed);
             var payload = JsonUtility.ToJson(spawn);
             var message = new NetworkMessage(MessageType.SpawnPlayer, payload);
             networkManager.SendMessage(connection, message);

--- a/CodexTest/Assets/Scripts/Networking/Messages/SpawnPlayer.cs
+++ b/CodexTest/Assets/Scripts/Networking/Messages/SpawnPlayer.cs
@@ -10,10 +10,20 @@ namespace Game.Networking.Messages
     public struct SpawnPlayer
     {
         public int EntityId;
+        /// <summary>
+        /// Walk speed for local prediction.
+        /// </summary>
+        public float WalkSpeed;
+        /// <summary>
+        /// Run speed for local prediction.
+        /// </summary>
+        public float RunSpeed;
 
-        public SpawnPlayer(Entity entity)
+        public SpawnPlayer(Entity entity, float walkSpeed, float runSpeed)
         {
             EntityId = entity.Id;
+            WalkSpeed = walkSpeed;
+            RunSpeed = runSpeed;
         }
     }
 }

--- a/SetupGuide.md
+++ b/SetupGuide.md
@@ -40,6 +40,8 @@ Place the provided `.cs` files into their matching folders.
    - `ReplicationSystem`
    - `SurvivalSystem`
    - `SurvivalReplicationSystem`
+
+   Player movement uses a `MovementSpeedComponent` configured on the server. Walk and run speeds are sent to the client when the player spawns so prediction matches the authoritative simulation.
 4. Create a **SurvivalConfig** asset (`Right Click → Create → Config → SurvivalConfig`) and assign it to `ServerBootstrap` to tweak starting stamina, hunger, drain, and regeneration rates.
 5. Open **File → Build Settings** and enable **Dedicated Server/Server Build** to produce a headless executable. (Leave this unchecked for client builds.)
 


### PR DESCRIPTION
## Summary
- Send walk/run speeds from server to client in `SpawnPlayer` message
- Initialize `ClientInputSender` with authoritative speeds to fix jerky prediction
- Document server-configured movement speeds in setup guide

## Testing
- `unity-editor -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d97a9ce1c8321a7d098ea201c5cda