### PR TITLE
feat: add movement configuration

### DIFF
--- a/CodexTest/Assets/Config.meta
+++ b/CodexTest/Assets/Config.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1cd38a3d88f74f69a8b438663c65a9f9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Config/MovementConfig.asset
+++ b/CodexTest/Assets/Config/MovementConfig.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac2f6cc0a3d84fb3a4c877bbecbe9f77, type: 3}
+  m_Name: MovementConfig
+  m_EditorClassIdentifier:
+  WalkSpeed: 2
+  RunSpeed: 4

--- a/CodexTest/Assets/Config/MovementConfig.asset.meta
+++ b/CodexTest/Assets/Config/MovementConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b0477a0cdef04660b8478bbf92888a5d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Scripts/Infrastructure/MovementConfig.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/MovementConfig.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace Game.Infrastructure
+{
+    /// <summary>
+    /// ScriptableObject holding movement speed settings.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Config/MovementConfig")]
+    public class MovementConfig : ScriptableObject
+    {
+        public float WalkSpeed = 2f;
+        public float RunSpeed = 4f;
+    }
+}

--- a/CodexTest/Assets/Scripts/Infrastructure/MovementConfig.cs.meta
+++ b/CodexTest/Assets/Scripts/Infrastructure/MovementConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac2f6cc0a3d84fb3a4c877bbecbe9f77
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
@@ -19,6 +19,7 @@ namespace Game.Infrastructure
     {
         [SerializeField] private ushort port = 80;
         [SerializeField] private SurvivalConfig survivalConfig;
+        [SerializeField] private MovementConfig movementConfig;
 
         private World world;
         private EventBus eventBus;
@@ -46,6 +47,10 @@ namespace Game.Infrastructure
             {
                 survivalConfig = ScriptableObject.CreateInstance<SurvivalConfig>();
             }
+            if (movementConfig == null)
+            {
+                movementConfig = ScriptableObject.CreateInstance<MovementConfig>();
+            }
             connectionToEntity = new Dictionary<NetworkConnection, Entity>();
             networkManager.OnClientConnected += OnClientConnected;
             networkManager.OnClientDisconnected += OnClientDisconnected;
@@ -64,7 +69,11 @@ namespace Game.Infrastructure
         {
             var entity = world.CreateEntity();
             world.AddComponent(entity, new PositionComponent { Value = Vector3.zero });
-            var speedComponent = new MovementSpeedComponent { WalkSpeed = 2f, RunSpeed = 4f };
+            var speedComponent = new MovementSpeedComponent
+            {
+                WalkSpeed = movementConfig.WalkSpeed,
+                RunSpeed = movementConfig.RunSpeed
+            };
             world.AddComponent(entity, speedComponent);
             world.AddComponent(entity, new StaminaComponent
             {

--- a/CodexTest/Assets/ServerScene.unity
+++ b/CodexTest/Assets/ServerScene.unity
@@ -149,9 +149,11 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e087988331ec72345b9d16622a067626, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   port: 80
+  survivalConfig: {fileID: 0}
+  movementConfig: {fileID: 11400000, guid: b0477a0cdef04660b8478bbf92888a5d, type: 2}
 --- !u!4 &683224130
 Transform:
   m_ObjectHideFlags: 0

--- a/SetupGuide.md
+++ b/SetupGuide.md
@@ -42,8 +42,9 @@ Place the provided `.cs` files into their matching folders.
    - `SurvivalReplicationSystem`
 
    Player movement uses a `MovementSpeedComponent` configured on the server. Walk and run speeds are sent to the client when the player spawns so prediction matches the authoritative simulation.
-4. Create a **SurvivalConfig** asset (`Right Click → Create → Config → SurvivalConfig`) and assign it to `ServerBootstrap` to tweak starting stamina, hunger, drain, and regeneration rates.
-5. Open **File → Build Settings** and enable **Dedicated Server/Server Build** to produce a headless executable. (Leave this unchecked for client builds.)
+4. Create a **MovementConfig** asset (`Right Click → Create → Config → MovementConfig`) and assign it to `ServerBootstrap` to configure authoritative walk and run speeds.
+5. Create a **SurvivalConfig** asset (`Right Click → Create → Config → SurvivalConfig`) and assign it to `ServerBootstrap` to tweak starting stamina, hunger, drain, and regeneration rates.
+6. Open **File → Build Settings** and enable **Dedicated Server/Server Build** to produce a headless executable. (Leave this unchecked for client builds.)
 
 ## 4. Client Scene
 1. Create a new scene for the client.


### PR DESCRIPTION
## Summary
- add MovementConfig scriptable object to configure walk and run speeds
- inject MovementConfig into ServerBootstrap and remove hardcoded speeds
- update server scene and setup guide for MovementConfig asset

## Testing
- `rg MovementConfig -n`
- `rg movementConfig -n CodexTest/Assets/ServerScene.unity`


------
https://chatgpt.com/codex/tasks/task_e_689d9be8f5ac83218ac4497e7fed1b56