### PR TITLE
Server-authoritative jump and stamina walk fix

### DIFF
--- a/CodexTest/Assets/Config/MovementConfig.asset
+++ b/CodexTest/Assets/Config/MovementConfig.asset
@@ -14,3 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   WalkSpeed: 5
   RunSpeed: 15
+  JumpForce: 5
+  Gravity: -9.81

--- a/CodexTest/Assets/Scripts/Components/JumpSettingsComponent.cs
+++ b/CodexTest/Assets/Scripts/Components/JumpSettingsComponent.cs
@@ -1,0 +1,15 @@
+using System;
+using Game.Domain.ECS;
+
+namespace Game.Components
+{
+    /// <summary>
+    /// Defines jump force and gravity for an entity.
+    /// </summary>
+    [Serializable]
+    public struct JumpSettingsComponent : IComponent
+    {
+        public float JumpForce;
+        public float Gravity;
+    }
+}

--- a/CodexTest/Assets/Scripts/Components/JumpSettingsComponent.cs.meta
+++ b/CodexTest/Assets/Scripts/Components/JumpSettingsComponent.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 1234567890abcdef1234567890abcdef
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/Domain/Commands/JumpCommand.cs
+++ b/CodexTest/Assets/Scripts/Domain/Commands/JumpCommand.cs
@@ -5,27 +5,23 @@ namespace Game.Domain.Commands
 {
     /// <summary>
     /// Command sent by client to request an entity jump.
-    /// Force represents the initial upward velocity applied.
     /// </summary>
     [Serializable]
     public struct JumpCommand
     {
         public Entity Entity;
-        public float Force;
         public int ClientId;
 
-        public JumpCommand(Entity entity, float force)
+        public JumpCommand(Entity entity)
         {
             Entity = entity;
-            Force = force;
             ClientId = 0;
         }
 
-        public JumpCommand(int clientId, Entity entity, float force)
+        public JumpCommand(int clientId, Entity entity)
         {
             ClientId = clientId;
             Entity = entity;
-            Force = force;
         }
     }
 }

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
@@ -82,7 +82,7 @@ namespace Game.Infrastructure
             var entity = new Entity(spawn.EntityId);
             if (inputSender != null)
             {
-                inputSender.Initialize(networkManager, entity, playerVisual, spawn.WalkSpeed, spawn.RunSpeed);
+                inputSender.Initialize(networkManager, entity, playerVisual, spawn.WalkSpeed, spawn.RunSpeed, spawn.JumpForce, spawn.Gravity);
             }
             snapshotReceiver.Initialize(networkManager, playerVisual);
             snapshotReceiver.RegisterEntity(entity.Id, playerVisual);

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
@@ -28,7 +28,7 @@ namespace Game.Infrastructure
         /// <summary>
         /// Injects dependencies from ClientBootstrap.
         /// </summary>
-        public void Initialize(NetworkManager manager, Entity playerEntity, Transform target, float walkSpeed, float runSpeed)
+        public void Initialize(NetworkManager manager, Entity playerEntity, Transform target, float walkSpeed, float runSpeed, float jumpForce, float gravity)
         {
             networkManager = manager;
             PlayerEntity = playerEntity;
@@ -36,6 +36,8 @@ namespace Game.Infrastructure
             _fixedDeltaTime = 1f / Constants.ServerTickRate;
             this.walkSpeed = walkSpeed;
             this.runSpeed = runSpeed;
+            this.jumpForce = jumpForce;
+            this.gravity = gravity;
         }
 
         /// <summary>
@@ -67,7 +69,7 @@ namespace Game.Infrastructure
             if (context.performed && Mathf.Abs(_verticalVelocity) < 0.01f && _target.position.y <= 0f)
             {
                 _verticalVelocity = jumpForce;
-                var command = new JumpCommand(PlayerEntity, jumpForce);
+                var command = new JumpCommand(PlayerEntity);
                 var payload = JsonUtility.ToJson(command);
                 var message = new NetworkMessage(MessageType.JumpCommand, payload);
                 networkManager.SendMessage(message);

--- a/CodexTest/Assets/Scripts/Infrastructure/MovementConfig.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/MovementConfig.cs
@@ -10,5 +10,13 @@ namespace Game.Infrastructure
     {
         public float WalkSpeed = 2f;
         public float RunSpeed = 4f;
+        /// <summary>
+        /// Upward velocity applied when jumping.
+        /// </summary>
+        public float JumpForce = 5f;
+        /// <summary>
+        /// Gravity applied to vertical motion.
+        /// </summary>
+        public float Gravity = -9.81f;
     }
 }

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
@@ -75,6 +75,11 @@ namespace Game.Infrastructure
                 RunSpeed = movementConfig.RunSpeed
             };
             world.AddComponent(entity, speedComponent);
+            world.AddComponent(entity, new JumpSettingsComponent
+            {
+                JumpForce = movementConfig.JumpForce,
+                Gravity = movementConfig.Gravity
+            });
             world.AddComponent(entity, new StaminaComponent
             {
                 Current = survivalConfig.MaxStamina,
@@ -94,7 +99,7 @@ namespace Game.Infrastructure
             eventBus.Publish(new HungerChangedEvent(entity, survivalConfig.MaxHunger, survivalConfig.MaxHunger));
             connectionToEntity[connection] = entity;
 
-            var spawn = new SpawnPlayer(entity, speedComponent.WalkSpeed, speedComponent.RunSpeed);
+            var spawn = new SpawnPlayer(entity, speedComponent.WalkSpeed, speedComponent.RunSpeed, movementConfig.JumpForce, movementConfig.Gravity);
             var payload = JsonUtility.ToJson(spawn);
             var message = new NetworkMessage(MessageType.SpawnPlayer, payload);
             networkManager.SendMessage(connection, message);

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
@@ -49,7 +49,7 @@ namespace Game.Infrastructure
                 var cmd = JsonUtility.FromJson<JumpCommand>(payload);
                 if (!cmd.Equals(default(JumpCommand)) && _connectionToEntity.TryGetValue(conn, out var entity))
                 {
-                    var validated = new JumpCommand(entity, cmd.Force);
+                    var validated = new JumpCommand(entity);
                     _eventBus.Publish(validated);
                 }
             };

--- a/CodexTest/Assets/Scripts/Networking/Messages/SpawnPlayer.cs
+++ b/CodexTest/Assets/Scripts/Networking/Messages/SpawnPlayer.cs
@@ -18,12 +18,22 @@ namespace Game.Networking.Messages
         /// Run speed for local prediction.
         /// </summary>
         public float RunSpeed;
+        /// <summary>
+        /// Jump force for local prediction.
+        /// </summary>
+        public float JumpForce;
+        /// <summary>
+        /// Gravity for local prediction.
+        /// </summary>
+        public float Gravity;
 
-        public SpawnPlayer(Entity entity, float walkSpeed, float runSpeed)
+        public SpawnPlayer(Entity entity, float walkSpeed, float runSpeed, float jumpForce, float gravity)
         {
             EntityId = entity.Id;
             WalkSpeed = walkSpeed;
             RunSpeed = runSpeed;
+            JumpForce = jumpForce;
+            Gravity = gravity;
         }
     }
 }

--- a/CodexTest/Assets/Scripts/Systems/JumpSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/JumpSystem.cs
@@ -16,7 +16,6 @@ namespace Game.Systems
         private readonly World _world;
         private readonly EventBus _eventBus;
         private float _fixedDeltaTime;
-        private const float Gravity = -9.81f;
 
         public JumpSystem(World world, EventBus eventBus)
         {
@@ -32,9 +31,10 @@ namespace Game.Systems
             foreach (var (entity, vel) in velocities)
             {
                 var velocity = vel;
-                if (_world.TryGetComponent(entity, out PositionComponent position))
+                if (_world.TryGetComponent(entity, out PositionComponent position) &&
+                    _world.TryGetComponent(entity, out JumpSettingsComponent jump))
                 {
-                    velocity.Value += Gravity * _fixedDeltaTime;
+                    velocity.Value += jump.Gravity * _fixedDeltaTime;
                     position.Value.y += velocity.Value * _fixedDeltaTime;
                     if (position.Value.y <= 0f)
                     {
@@ -50,16 +50,17 @@ namespace Game.Systems
 
         private void OnJumpCommand(JumpCommand command)
         {
-            if (_world.TryGetComponent(command.Entity, out PositionComponent position) && position.Value.y <= 0f)
+            if (_world.TryGetComponent(command.Entity, out PositionComponent position) && position.Value.y <= 0f &&
+                _world.TryGetComponent(command.Entity, out JumpSettingsComponent jump))
             {
                 if (_world.TryGetComponent(command.Entity, out VerticalVelocityComponent velocity))
                 {
-                    velocity.Value = command.Force;
+                    velocity.Value = jump.JumpForce;
                     _world.SetComponent(command.Entity, velocity);
                 }
                 else
                 {
-                    _world.AddComponent(command.Entity, new VerticalVelocityComponent { Value = command.Force });
+                    _world.AddComponent(command.Entity, new VerticalVelocityComponent { Value = jump.JumpForce });
                 }
             }
         }

--- a/CodexTest/Assets/Scripts/Systems/MovementSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/MovementSystem.cs
@@ -37,20 +37,20 @@ namespace Game.Systems
 
             // Determine movement mode based on stamina and desired state.
             bool isRunning = command.IsRunning && command.Direction.sqrMagnitude > 0f;
-            float speed = command.Speed;
 
-            if (_world.TryGetComponent(command.Entity, out StaminaComponent stamina))
+            if (_world.TryGetComponent(command.Entity, out StaminaComponent stamina) && isRunning && stamina.Current <= 0f)
             {
-                if (isRunning && stamina.Current <= 0f)
-                {
-                    isRunning = false;
-                }
+                isRunning = false;
+            }
 
-                // Use configured speeds instead of trusting client supplied speed.
-                if (_world.TryGetComponent(command.Entity, out MovementSpeedComponent moveSpeed))
-                {
-                    speed = isRunning ? moveSpeed.RunSpeed : moveSpeed.WalkSpeed;
-                }
+            float speed;
+            if (_world.TryGetComponent(command.Entity, out MovementSpeedComponent moveSpeed))
+            {
+                speed = isRunning ? moveSpeed.RunSpeed : moveSpeed.WalkSpeed;
+            }
+            else
+            {
+                speed = command.Speed;
             }
 
             // Physics-based movement with simple collision check.

--- a/CodexTest/Assets/Scripts/Systems/SurvivalSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/SurvivalSystem.cs
@@ -40,6 +40,15 @@ namespace Game.Systems
                 {
                     st.Current = Mathf.Max(0f, st.Current - st.DrainPerSecond * _fixedDeltaTime);
                 }
+                else if (st.Current <= 0f && isRunning)
+                {
+                    // Force entity to stop running when stamina is depleted.
+                    if (_world.TryGetComponent(entity, out MovementStateComponent state))
+                    {
+                        state.IsRunning = false;
+                        _world.SetComponent(entity, state);
+                    }
+                }
                 else if (_world.TryGetComponent(entity, out HungerComponent hunger) && hunger.Current > 0f)
                 {
                     st.Current = Mathf.Min(st.Max, st.Current + st.RegenPerSecond * _fixedDeltaTime);


### PR DESCRIPTION
## Summary
- Move jump force and gravity to server-authoritative settings shared via `JumpSettingsComponent`
- Add jump parameters to movement config and spawn message for client prediction
- Ensure stamina depletion toggles to walking and use server-defined speeds

## Testing
- `ls CodexTest/Assets/Tests` (fails: No such file or directory)

------
https://chatgpt.com/codex/tasks/task_e_689da136bca483218eef7158c6ee5207