### PR TITLE
Add unit tests for ECS systems and command handler

### DIFF
--- a/CodexTest/Assets/Scripts/Networking/NetworkManager.cs
+++ b/CodexTest/Assets/Scripts/Networking/NetworkManager.cs
@@ -132,7 +132,7 @@ namespace Game.Networking
             SendBytes(connection, Encoding.UTF8.GetBytes(json));
         }
 
-        public void SendMessage<T>(T message)
+        public virtual void SendMessage<T>(T message)
         {
             var json = JsonUtility.ToJson(message);
             SendBytes(Encoding.UTF8.GetBytes(json));

--- a/CodexTest/Assets/Tests.meta
+++ b/CodexTest/Assets/Tests.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 31e6fbcc8b814470ba1844eaf7f9960e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+

--- a/CodexTest/Assets/Tests/CommandHandlerTests.cs
+++ b/CodexTest/Assets/Tests/CommandHandlerTests.cs
@@ -1,0 +1,42 @@
+using Game.Domain;
+using Game.Domain.Commands;
+using Game.Domain.ECS;
+using Game.Infrastructure;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Tests
+{
+    public class CommandHandlerTests
+    {
+        [Test]
+        public void HandleMoveCommand_PublishesCommand()
+        {
+            var eventBus = new EventBus();
+            var handler = new CommandHandler(eventBus);
+            MoveCommand received = default;
+            eventBus.Subscribe<MoveCommand>(cmd => received = cmd);
+
+            var command = new MoveCommand(new Entity(1), Vector3.forward, 1f, false);
+            handler.Handle(command);
+
+            Assert.AreEqual(command.Entity, received.Entity);
+            Assert.AreEqual(command.Direction, received.Direction);
+        }
+
+        [Test]
+        public void HandleJumpCommand_PublishesCommand()
+        {
+            var eventBus = new EventBus();
+            var handler = new CommandHandler(eventBus);
+            JumpCommand received = default;
+            eventBus.Subscribe<JumpCommand>(cmd => received = cmd);
+
+            var command = new JumpCommand(new Entity(2));
+            handler.Handle(command);
+
+            Assert.AreEqual(command.Entity, received.Entity);
+        }
+    }
+}
+

--- a/CodexTest/Assets/Tests/CommandHandlerTests.cs.meta
+++ b/CodexTest/Assets/Tests/CommandHandlerTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a3d3a3ada987464bb5da35d305993309
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+

--- a/CodexTest/Assets/Tests/MovementSystemTests.cs
+++ b/CodexTest/Assets/Tests/MovementSystemTests.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using Game.Components;
+using Game.Domain.Commands;
+using Game.Domain.ECS;
+using Game.Domain.Events;
+using Game.Infrastructure;
+using Game.Systems;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Tests
+{
+    public class MovementSystemTests
+    {
+        [Test]
+        public void MoveCommandUpdatesPositionAndState()
+        {
+            var world = new World();
+            var eventBus = new EventBus();
+            var system = new MovementSystem(world, eventBus);
+            var entity = world.CreateEntity();
+            world.AddComponent(entity, new PositionComponent { Value = Vector3.zero });
+            world.AddComponent(entity, new MovementSpeedComponent { WalkSpeed = 1f, RunSpeed = 2f });
+            world.AddComponent(entity, new StaminaComponent { Current = 5f, Max = 5f });
+
+            var events = new List<PositionChangedEvent>();
+            eventBus.Subscribe<PositionChangedEvent>(e => events.Add(e));
+
+            system.Update(world, 1f);
+            eventBus.Publish(new MoveCommand(entity, Vector3.right, 0f, true));
+
+            Assert.IsTrue(world.TryGetComponent(entity, out PositionComponent pos));
+            Assert.AreEqual(2f, pos.Value.x, 1e-5f);
+            Assert.AreEqual(1, events.Count);
+            Assert.AreEqual(new Vector3(2f, 0f, 0f), events[0].Position);
+            Assert.IsTrue(world.TryGetComponent(entity, out MovementStateComponent state));
+            Assert.IsTrue(state.IsRunning);
+        }
+
+        [Test]
+        public void MoveCommandWithoutStaminaFallsBackToWalk()
+        {
+            var world = new World();
+            var eventBus = new EventBus();
+            var system = new MovementSystem(world, eventBus);
+            var entity = world.CreateEntity();
+            world.AddComponent(entity, new PositionComponent { Value = Vector3.zero });
+            world.AddComponent(entity, new MovementSpeedComponent { WalkSpeed = 1f, RunSpeed = 2f });
+            world.AddComponent(entity, new StaminaComponent { Current = 0f, Max = 5f });
+
+            system.Update(world, 1f);
+            eventBus.Publish(new MoveCommand(entity, Vector3.right, 0f, true));
+
+            Assert.IsTrue(world.TryGetComponent(entity, out PositionComponent pos));
+            Assert.AreEqual(1f, pos.Value.x, 1e-5f);
+            Assert.IsTrue(world.TryGetComponent(entity, out MovementStateComponent state));
+            Assert.IsFalse(state.IsRunning);
+        }
+    }
+}
+

--- a/CodexTest/Assets/Tests/MovementSystemTests.cs.meta
+++ b/CodexTest/Assets/Tests/MovementSystemTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9a58acf35e0c474bad68392b8f3e282c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+

--- a/CodexTest/Assets/Tests/ReplicationSystemTests.cs
+++ b/CodexTest/Assets/Tests/ReplicationSystemTests.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using Game.Domain.ECS;
+using Game.Domain.Events;
+using Game.Infrastructure;
+using Game.Networking;
+using Game.Networking.Messages;
+using Game.Systems;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Tests
+{
+    public class ReplicationSystemTests
+    {
+        private class TestNetworkManager : NetworkManager
+        {
+            public readonly List<NetworkMessage> Sent = new();
+            public override void SendMessage<T>(T message)
+            {
+                if (message is NetworkMessage nm)
+                {
+                    Sent.Add(nm);
+                }
+            }
+        }
+
+        [Test]
+        public void PositionChangedEvent_SendsSnapshotMessage()
+        {
+            var network = new TestNetworkManager();
+            var eventBus = new EventBus();
+            var system = new ReplicationSystem(network, eventBus);
+
+            var entity = new Entity(42);
+            var position = new Vector3(1f, 2f, 3f);
+            eventBus.Publish(new PositionChangedEvent(entity, position));
+
+            Assert.AreEqual(1, network.Sent.Count);
+            var message = network.Sent[0];
+            Assert.AreEqual(MessageType.PositionSnapshot, message.Type);
+
+            var snapshot = JsonUtility.FromJson<PositionSnapshot>(message.Payload);
+            Assert.AreEqual(entity.Id, snapshot.EntityId);
+            Assert.AreEqual(position, snapshot.Position);
+        }
+    }
+}
+

--- a/CodexTest/Assets/Tests/ReplicationSystemTests.cs.meta
+++ b/CodexTest/Assets/Tests/ReplicationSystemTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: eac76a60dfa24426847924f9b30fb6d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+

--- a/CodexTest/Assets/Tests/Tests.asmdef
+++ b/CodexTest/Assets/Tests/Tests.asmdef
@@ -1,0 +1,15 @@
+{
+  "name": "Tests",
+  "references": ["Assembly-CSharp"],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false,
+  "testAssemblies": true
+}
+

--- a/CodexTest/Assets/Tests/Tests.asmdef.meta
+++ b/CodexTest/Assets/Tests/Tests.asmdef.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 892298526d9841d094479f29a8908b81
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+


### PR DESCRIPTION
## Summary
- add Unity Test Runner assembly and tests for movement, command handling, and replication systems
- allow NetworkManager.SendMessage to be overridden for test doubles

## Testing
- `Unity -runTests -batchmode -projectPath . -testResults results.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689da2bd77dc8321b4d9e705900f01ec