### PR TITLE
Ensure client stops running when stamina empty

### DIFF
--- a/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
@@ -82,7 +82,7 @@ namespace Game.Infrastructure
             var entity = new Entity(spawn.EntityId);
             if (inputSender != null)
             {
-                inputSender.Initialize(networkManager, entity, playerVisual, spawn.WalkSpeed, spawn.RunSpeed, spawn.JumpForce, spawn.Gravity);
+                inputSender.Initialize(networkManager, eventBus, entity, playerVisual, spawn.WalkSpeed, spawn.RunSpeed, spawn.JumpForce, spawn.Gravity);
             }
             snapshotReceiver.Initialize(networkManager, playerVisual);
             snapshotReceiver.RegisterEntity(entity.Id, playerVisual);


### PR DESCRIPTION
## Summary
- Track current stamina on the client via EventBus.
- Prevent running and send walk-speed MoveCommands when stamina is depleted.
- Inject EventBus into ClientInputSender during bootstrap.

## Testing
- ⚠️ `ls CodexTest/Assets/Tests` *(directory not found, no tests to run)*

------
https://chatgpt.com/codex/tasks/task_e_689da6901ec08321a1731352b3b3e637