### PR TITLE
Expand test coverage for survival and jump systems

### DIFF
--- a/CodexTest/Assets/Tests/JumpSystemTests.cs
+++ b/CodexTest/Assets/Tests/JumpSystemTests.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using Game.Components;
+using Game.Domain.Commands;
+using Game.Domain.ECS;
+using Game.Domain.Events;
+using Game.Infrastructure;
+using Game.Systems;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Tests
+{
+    public class JumpSystemTests
+    {
+        [Test]
+        public void JumpCommandAddsVerticalVelocity()
+        {
+            var world = new World();
+            var eventBus = new EventBus();
+            var system = new JumpSystem(world, eventBus);
+            var entity = world.CreateEntity();
+            world.AddComponent(entity, new PositionComponent { Value = Vector3.zero });
+            world.AddComponent(entity, new JumpSettingsComponent { JumpForce = 5f, Gravity = -9.81f });
+
+            eventBus.Publish(new JumpCommand(entity));
+
+            Assert.IsTrue(world.TryGetComponent(entity, out VerticalVelocityComponent vel));
+            Assert.AreEqual(5f, vel.Value, 1e-5f);
+        }
+
+        [Test]
+        public void UpdateIntegratesGravityAndLanding()
+        {
+            var world = new World();
+            var eventBus = new EventBus();
+            var system = new JumpSystem(world, eventBus);
+            var entity = world.CreateEntity();
+            world.AddComponent(entity, new PositionComponent { Value = Vector3.zero });
+            world.AddComponent(entity, new JumpSettingsComponent { JumpForce = 10f, Gravity = -9.8f });
+            eventBus.Publish(new JumpCommand(entity));
+
+            var events = new List<PositionChangedEvent>();
+            eventBus.Subscribe<PositionChangedEvent>(e => events.Add(e));
+
+            system.Update(world, 0.5f);
+
+            Assert.IsTrue(world.TryGetComponent(entity, out PositionComponent pos1));
+            Assert.IsTrue(world.TryGetComponent(entity, out VerticalVelocityComponent vel1));
+            Assert.AreEqual(2.55f, pos1.Value.y, 1e-2f);
+            Assert.AreEqual(5.1f, vel1.Value, 1e-2f);
+            Assert.AreEqual(1, events.Count);
+            Assert.AreEqual(2.55f, events[0].Position.y, 1e-2f);
+
+            system.Update(world, 1f);
+
+            Assert.IsTrue(world.TryGetComponent(entity, out PositionComponent pos2));
+            Assert.IsTrue(world.TryGetComponent(entity, out VerticalVelocityComponent vel2));
+            Assert.AreEqual(0f, pos2.Value.y, 1e-5f);
+            Assert.AreEqual(0f, vel2.Value, 1e-5f);
+            Assert.AreEqual(2, events.Count);
+            Assert.AreEqual(0f, events[1].Position.y, 1e-5f);
+        }
+    }
+}

--- a/CodexTest/Assets/Tests/JumpSystemTests.cs.meta
+++ b/CodexTest/Assets/Tests/JumpSystemTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2916f0483bd4e21be2cb88a260c38e9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Tests/SurvivalReplicationSystemTests.cs
+++ b/CodexTest/Assets/Tests/SurvivalReplicationSystemTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using Game.Domain.ECS;
+using Game.Domain.Events;
+using Game.Infrastructure;
+using Game.Networking;
+using Game.Networking.Messages;
+using Game.Systems;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Tests
+{
+    public class SurvivalReplicationSystemTests
+    {
+        private class TestNetworkManager : NetworkManager
+        {
+            public readonly List<NetworkMessage> Sent = new();
+            public override void SendMessage<T>(T message)
+            {
+                if (message is NetworkMessage nm)
+                {
+                    Sent.Add(nm);
+                }
+            }
+        }
+
+        [Test]
+        public void StaminaChangedEvent_SendsSnapshotMessage()
+        {
+            var network = new TestNetworkManager();
+            var eventBus = new EventBus();
+            var system = new SurvivalReplicationSystem(network, eventBus);
+
+            var entity = new Entity(10);
+            eventBus.Publish(new StaminaChangedEvent(entity, 3f, 5f));
+
+            Assert.AreEqual(1, network.Sent.Count);
+            var message = network.Sent[0];
+            Assert.AreEqual(MessageType.StaminaSnapshot, message.Type);
+            var snapshot = JsonUtility.FromJson<StaminaSnapshot>(message.Payload);
+            Assert.AreEqual(entity.Id, snapshot.EntityId);
+            Assert.AreEqual(3f, snapshot.Current);
+            Assert.AreEqual(5f, snapshot.Max);
+        }
+
+        [Test]
+        public void HungerChangedEvent_SendsSnapshotMessage()
+        {
+            var network = new TestNetworkManager();
+            var eventBus = new EventBus();
+            var system = new SurvivalReplicationSystem(network, eventBus);
+
+            var entity = new Entity(11);
+            eventBus.Publish(new HungerChangedEvent(entity, 2f, 5f));
+
+            Assert.AreEqual(1, network.Sent.Count);
+            var message = network.Sent[0];
+            Assert.AreEqual(MessageType.HungerSnapshot, message.Type);
+            var snapshot = JsonUtility.FromJson<HungerSnapshot>(message.Payload);
+            Assert.AreEqual(entity.Id, snapshot.EntityId);
+            Assert.AreEqual(2f, snapshot.Current);
+            Assert.AreEqual(5f, snapshot.Max);
+        }
+    }
+}

--- a/CodexTest/Assets/Tests/SurvivalReplicationSystemTests.cs.meta
+++ b/CodexTest/Assets/Tests/SurvivalReplicationSystemTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7fde21dd75f74047a5dec5c88f51628a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Tests/SurvivalSystemTests.cs
+++ b/CodexTest/Assets/Tests/SurvivalSystemTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using Game.Components;
+using Game.Domain.ECS;
+using Game.Domain.Events;
+using Game.Infrastructure;
+using Game.Systems;
+using NUnit.Framework;
+
+namespace Tests
+{
+    public class SurvivalSystemTests
+    {
+        [Test]
+        public void RunningDrainsStaminaAndStopsWhenEmpty()
+        {
+            var world = new World();
+            var eventBus = new EventBus();
+            var system = new SurvivalSystem(world, eventBus);
+            var entity = world.CreateEntity();
+            world.AddComponent(entity, new StaminaComponent { Current = 2f, Max = 5f, DrainPerSecond = 1f, RegenPerSecond = 1f });
+            world.AddComponent(entity, new HungerComponent { Current = 5f, Max = 5f, DrainPerSecond = 0f });
+            world.AddComponent(entity, new MovementStateComponent { IsRunning = true });
+
+            system.Update(world, 2f);
+            system.Update(world, 0.1f);
+
+            Assert.IsTrue(world.TryGetComponent(entity, out StaminaComponent stamina));
+            Assert.AreEqual(0f, stamina.Current, 1e-5f);
+            Assert.IsTrue(world.TryGetComponent(entity, out MovementStateComponent state));
+            Assert.IsFalse(state.IsRunning);
+        }
+
+        [Test]
+        public void StaminaRegeneratesWhenNotRunning()
+        {
+            var world = new World();
+            var eventBus = new EventBus();
+            var system = new SurvivalSystem(world, eventBus);
+            var entity = world.CreateEntity();
+            world.AddComponent(entity, new StaminaComponent { Current = 0f, Max = 5f, DrainPerSecond = 1f, RegenPerSecond = 2f });
+            world.AddComponent(entity, new HungerComponent { Current = 5f, Max = 5f, DrainPerSecond = 0f });
+            world.AddComponent(entity, new MovementStateComponent { IsRunning = false });
+
+            system.Update(world, 1f);
+
+            Assert.IsTrue(world.TryGetComponent(entity, out StaminaComponent stamina));
+            Assert.AreEqual(2f, stamina.Current, 1e-5f);
+        }
+
+        [Test]
+        public void HungerDecreasesOverTime()
+        {
+            var world = new World();
+            var eventBus = new EventBus();
+            var system = new SurvivalSystem(world, eventBus);
+            var entity = world.CreateEntity();
+            world.AddComponent(entity, new HungerComponent { Current = 5f, Max = 5f, DrainPerSecond = 1f });
+
+            var events = new List<HungerChangedEvent>();
+            eventBus.Subscribe<HungerChangedEvent>(e => events.Add(e));
+
+            system.Update(world, 2f);
+
+            Assert.IsTrue(world.TryGetComponent(entity, out HungerComponent hunger));
+            Assert.AreEqual(3f, hunger.Current, 1e-5f);
+            Assert.AreEqual(1, events.Count);
+            Assert.AreEqual(3f, events[0].Current, 1e-5f);
+        }
+    }
+}

--- a/CodexTest/Assets/Tests/SurvivalSystemTests.cs.meta
+++ b/CodexTest/Assets/Tests/SurvivalSystemTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20934452d2d64601b4fa54d629a74f24
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add unit tests for jump commands and gravity updates
- cover survival stamina and hunger logic with new tests
- ensure survival stats replication emits correct network messages

## Testing
- `unity-editor -runTests -projectPath . -testResults /tmp/test-results.xml -batchmode -nographics -assemblyNames Tests` *(command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689dac0ffd58832191af40f5f5374c22