### PR TITLE
Add stub game framework for tests

### DIFF
--- a/CodexTest/Assets/Tests/Stubs.meta
+++ b/CodexTest/Assets/Tests/Stubs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bdc8b48b524f44349207f9d593922518
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Tests/Stubs/Commands.cs
+++ b/CodexTest/Assets/Tests/Stubs/Commands.cs
@@ -1,0 +1,48 @@
+using System;
+using UnityEngine;
+using Game.Domain.ECS;
+using Game.Infrastructure;
+
+namespace Game.Domain.Commands
+{
+    /// <summary>Command requesting entity movement.</summary>
+    [Serializable]
+    public struct MoveCommand
+    {
+        public Entity Entity;
+        public Vector3 Direction;
+        public float Speed;
+        public bool IsRunning;
+        public MoveCommand(Entity entity, Vector3 direction, float speed, bool isRunning)
+        {
+            Entity = entity;
+            Direction = direction;
+            Speed = speed;
+            IsRunning = isRunning;
+        }
+    }
+
+    /// <summary>Command requesting entity jump.</summary>
+    [Serializable]
+    public struct JumpCommand
+    {
+        public Entity Entity;
+        public JumpCommand(Entity entity)
+        {
+            Entity = entity;
+        }
+    }
+}
+
+namespace Game.Domain
+{
+    /// <summary>Dispatches commands via the EventBus.</summary>
+    public class CommandHandler
+    {
+        private readonly EventBus _eventBus;
+        public CommandHandler(EventBus eventBus) => _eventBus = eventBus;
+
+        public void Handle(Game.Domain.Commands.MoveCommand command) => _eventBus.Publish(command);
+        public void Handle(Game.Domain.Commands.JumpCommand command) => _eventBus.Publish(command);
+    }
+}

--- a/CodexTest/Assets/Tests/Stubs/Commands.cs.meta
+++ b/CodexTest/Assets/Tests/Stubs/Commands.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d45b1c35bd2474c8567c3aa46fc1077
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Tests/Stubs/Components.cs
+++ b/CodexTest/Assets/Tests/Stubs/Components.cs
@@ -1,0 +1,31 @@
+using Game.Domain.ECS;
+using UnityEngine;
+
+namespace Game.Components
+{
+    /// <summary>Holds world position of an entity.</summary>
+    public struct PositionComponent : IComponent
+    {
+        public Vector3 Value;
+    }
+
+    /// <summary>Walk and run speeds for an entity.</summary>
+    public struct MovementSpeedComponent : IComponent
+    {
+        public float WalkSpeed;
+        public float RunSpeed;
+    }
+
+    /// <summary>Represents stamina for sprinting.</summary>
+    public struct StaminaComponent : IComponent
+    {
+        public float Current;
+        public float Max;
+    }
+
+    /// <summary>Current movement state such as running or walking.</summary>
+    public struct MovementStateComponent : IComponent
+    {
+        public bool IsRunning;
+    }
+}

--- a/CodexTest/Assets/Tests/Stubs/Components.cs.meta
+++ b/CodexTest/Assets/Tests/Stubs/Components.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af7c1758c1a043919bb216e92e1fb67d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Tests/Stubs/ECS.cs
+++ b/CodexTest/Assets/Tests/Stubs/ECS.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+
+namespace Game.Domain.ECS
+{
+    /// <summary>
+    /// Marker interface for components.
+    /// </summary>
+    public interface IComponent { }
+
+    /// <summary>
+    /// Identifier for entities in the world.
+    /// </summary>
+    public readonly struct Entity
+    {
+        public readonly int Id;
+        public Entity(int id) => Id = id;
+    }
+
+    /// <summary>
+    /// Interface for all ECS systems.
+    /// </summary>
+    public interface ISystem
+    {
+        void Update(World world, float deltaTime);
+    }
+
+    /// <summary>
+    /// Minimal ECS world used for unit tests.
+    /// Stores components in dictionaries keyed by entity id.
+    /// </summary>
+    public class World
+    {
+        private int _nextId;
+        private readonly Dictionary<Type, Dictionary<int, IComponent>> _components = new();
+
+        public Entity CreateEntity() => new Entity(_nextId++);
+
+        public void AddComponent<T>(Entity entity, T component) where T : IComponent
+        {
+            var type = typeof(T);
+            if (!_components.TryGetValue(type, out var map))
+            {
+                map = new Dictionary<int, IComponent>();
+                _components[type] = map;
+            }
+            map[entity.Id] = component;
+        }
+
+        public bool TryGetComponent<T>(Entity entity, out T component) where T : IComponent
+        {
+            component = default;
+            var type = typeof(T);
+            if (_components.TryGetValue(type, out var map) && map.TryGetValue(entity.Id, out var value))
+            {
+                component = (T)value;
+                return true;
+            }
+            return false;
+        }
+
+        public void SetComponent<T>(Entity entity, T component) where T : IComponent
+        {
+            var type = typeof(T);
+            if (_components.TryGetValue(type, out var map))
+            {
+                map[entity.Id] = component;
+            }
+        }
+    }
+}

--- a/CodexTest/Assets/Tests/Stubs/ECS.cs.meta
+++ b/CodexTest/Assets/Tests/Stubs/ECS.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8328b478b525465c8988ba589f012d7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Tests/Stubs/Events.cs
+++ b/CodexTest/Assets/Tests/Stubs/Events.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+using Game.Domain.ECS;
+
+namespace Game.Domain.Events
+{
+    /// <summary>Raised when an entity's position changes.</summary>
+    public readonly struct PositionChangedEvent
+    {
+        public readonly Entity Entity;
+        public readonly Vector3 Position;
+        public PositionChangedEvent(Entity entity, Vector3 position)
+        {
+            Entity = entity;
+            Position = position;
+        }
+    }
+}

--- a/CodexTest/Assets/Tests/Stubs/Events.cs.meta
+++ b/CodexTest/Assets/Tests/Stubs/Events.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f09ada2106342bdb2c6569b1d503963
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Tests/Stubs/Infrastructure.cs
+++ b/CodexTest/Assets/Tests/Stubs/Infrastructure.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+
+namespace Game.Infrastructure
+{
+    /// <summary>Simple event bus for decoupled communication between systems.</summary>
+    public class EventBus
+    {
+        private readonly Dictionary<Type, List<Delegate>> _subscribers = new();
+
+        public void Subscribe<T>(Action<T> handler)
+        {
+            var type = typeof(T);
+            if (!_subscribers.TryGetValue(type, out var list))
+            {
+                list = new List<Delegate>();
+                _subscribers[type] = list;
+            }
+            list.Add(handler);
+        }
+
+        public void Publish<T>(T evt)
+        {
+            var type = typeof(T);
+            if (_subscribers.TryGetValue(type, out var list))
+            {
+                foreach (var handler in list)
+                {
+                    ((Action<T>)handler)?.Invoke(evt);
+                }
+            }
+        }
+    }
+}

--- a/CodexTest/Assets/Tests/Stubs/Infrastructure.cs.meta
+++ b/CodexTest/Assets/Tests/Stubs/Infrastructure.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 698b78ac2f4c407eb38e267cd49390ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Tests/Stubs/Networking.cs
+++ b/CodexTest/Assets/Tests/Stubs/Networking.cs
@@ -1,0 +1,52 @@
+using System;
+using Game.Domain.ECS;
+using UnityEngine;
+
+namespace Game.Networking
+{
+    /// <summary>Stub network manager used for tests.</summary>
+    public class NetworkManager
+    {
+        public virtual void SendMessage<T>(T message) { }
+    }
+}
+
+namespace Game.Networking.Messages
+{
+    public enum MessageType
+    {
+        MoveCommand = 1,
+        PositionSnapshot = 2,
+        JumpCommand = 3,
+        SpawnPlayer = 4,
+        Ping = 5,
+        HungerSnapshot = 6,
+        StaminaSnapshot = 7
+    }
+
+    /// <summary>Envelope for network messages.</summary>
+    [Serializable]
+    public struct NetworkMessage
+    {
+        public MessageType Type;
+        public string Payload;
+        public NetworkMessage(MessageType type, string payload)
+        {
+            Type = type;
+            Payload = payload;
+        }
+    }
+
+    /// <summary>Snapshot message containing entity position.</summary>
+    [Serializable]
+    public struct PositionSnapshot
+    {
+        public int EntityId;
+        public Vector3 Position;
+        public PositionSnapshot(Entity entity, Vector3 position)
+        {
+            EntityId = entity.Id;
+            Position = position;
+        }
+    }
+}

--- a/CodexTest/Assets/Tests/Stubs/Networking.cs.meta
+++ b/CodexTest/Assets/Tests/Stubs/Networking.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86a4cced9aab491ab3bfee28048167f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Tests/Stubs/Systems.cs
+++ b/CodexTest/Assets/Tests/Stubs/Systems.cs
@@ -1,0 +1,75 @@
+using Game.Components;
+using Game.Domain.Commands;
+using Game.Domain.ECS;
+using Game.Domain.Events;
+using Game.Infrastructure;
+using Game.Networking;
+using Game.Networking.Messages;
+using UnityEngine;
+
+namespace Game.Systems
+{
+    /// <summary>Processes MoveCommand events and updates positions.</summary>
+    public class MovementSystem : ISystem
+    {
+        private readonly World _world;
+        private readonly EventBus _eventBus;
+        private float _delta;
+
+        public MovementSystem(World world, EventBus eventBus)
+        {
+            _world = world;
+            _eventBus = eventBus;
+            _eventBus.Subscribe<MoveCommand>(OnMoveCommand);
+        }
+
+        public void Update(World world, float deltaTime)
+        {
+            _delta = deltaTime;
+        }
+
+        private void OnMoveCommand(MoveCommand command)
+        {
+            if (!_world.TryGetComponent(command.Entity, out PositionComponent pos))
+                return;
+
+            bool isRunning = command.IsRunning && command.Direction.sqrMagnitude > 0f;
+            if (_world.TryGetComponent(command.Entity, out StaminaComponent stamina) && isRunning && stamina.Current <= 0f)
+                isRunning = false;
+
+            float speed = command.Speed;
+            if (_world.TryGetComponent(command.Entity, out MovementSpeedComponent moveSpeed))
+                speed = isRunning ? moveSpeed.RunSpeed : moveSpeed.WalkSpeed;
+
+            Vector3 dir = command.Direction.normalized;
+            pos.Value += dir * speed * _delta;
+            _world.SetComponent(command.Entity, pos);
+            _world.SetComponent(command.Entity, new MovementStateComponent { IsRunning = isRunning });
+            _eventBus.Publish(new PositionChangedEvent(command.Entity, pos.Value));
+        }
+    }
+
+    /// <summary>Sends snapshot messages when positions change.</summary>
+    public class ReplicationSystem : ISystem
+    {
+        private readonly NetworkManager _networkManager;
+        private readonly EventBus _eventBus;
+
+        public ReplicationSystem(NetworkManager networkManager, EventBus eventBus)
+        {
+            _networkManager = networkManager;
+            _eventBus = eventBus;
+            _eventBus.Subscribe<PositionChangedEvent>(OnPositionChanged);
+        }
+
+        public void Update(World world, float deltaTime) { }
+
+        private void OnPositionChanged(PositionChangedEvent evt)
+        {
+            var snapshot = new PositionSnapshot(evt.Entity, evt.Position);
+            var payload = JsonUtility.ToJson(snapshot);
+            var message = new NetworkMessage(MessageType.PositionSnapshot, payload);
+            _networkManager.SendMessage(message);
+        }
+    }
+}

--- a/CodexTest/Assets/Tests/Stubs/Systems.cs.meta
+++ b/CodexTest/Assets/Tests/Stubs/Systems.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c79c26ecc6e4d3fa491691f7bcb4cb8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add minimal ECS, components, and command infrastructure used by tests
- provide stub networking and replication systems for snapshot messages
- include event bus and command handler implementations

## Testing
- `unity-editor -runTests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689da95486fc8321b402ae42d8b48824