### PR TITLE
fix: replace hyphenated GUIDs in meta files

### DIFF
--- a/CodexTest/Assets/Scripts/Infrastructure/EventBus.meta
+++ b/CodexTest/Assets/Scripts/Infrastructure/EventBus.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 973c6648-374a-458f-a34e-bc9e8eb1fd00
+guid: 973c6648374a458fa34ebc9e8eb1fd00
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/CodexTest/Assets/Scripts/Infrastructure/EventBus/EventBus.asmdef.meta
+++ b/CodexTest/Assets/Scripts/Infrastructure/EventBus/EventBus.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 55315772-d624-441d-9f88-698f253c7b74
+guid: 55315772d624441d9f88698f253c7b74
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData:

--- a/CodexTest/Assets/Scripts/Networking/Networking.asmdef.meta
+++ b/CodexTest/Assets/Scripts/Networking/Networking.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b7cede02-d513-4310-ab1a-e57ae4b77da3
+guid: b7cede02d5134310ab1ae57ae4b77da3
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData:

--- a/CodexTest/Assets/Scripts/Utils/Utils.asmdef.meta
+++ b/CodexTest/Assets/Scripts/Utils/Utils.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 86593cae-a023-440b-81c8-bcc65033cd80
+guid: 86593caea023440b81c8bcc65033cd80
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData:


### PR DESCRIPTION
## Summary
- fix GUID format for EventBus folder meta
- fix GUID format for EventBus asmdef meta
- fix GUID format for Networking and Utils asmdef meta

## Testing
- `unity-editor -batchmode -projectPath CodexTest -runTests -logFile -` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689db4c987888321bb568d556e9b3ead