### PR TITLE
Add Game.Domain reference to Networking asmdef

### DIFF
--- a/CodexTest/Assets/Scripts/Networking/Networking.asmdef
+++ b/CodexTest/Assets/Scripts/Networking/Networking.asmdef
@@ -1,6 +1,8 @@
 {
   "name": "Game.Networking",
-  "references": [],
+  "references": [
+    "Game.Domain"
+  ],
   "includePlatforms": [],
   "excludePlatforms": [],
   "allowUnsafeCode": false,


### PR DESCRIPTION
## Summary
- add `Game.Domain` to `Game.Networking` assembly references

## Testing
- `unity -quit -batchmode -projectPath . -executeMethod UnityEditor.AssetDatabase.Refresh` *(fails: command not found)*
- `unity -quit -batchmode -projectPath $(pwd)/CodexTest -runTests -testResults results.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689db7e72d1483218353e05f69623b6c