### PR TITLE
refactor: move EventBus to dedicated namespace

### DIFF
--- a/CodexTest/Assets/Scripts/Domain/CommandHandler.cs
+++ b/CodexTest/Assets/Scripts/Domain/CommandHandler.cs
@@ -1,5 +1,5 @@
 using Game.Domain.Commands;
-using Game.Infrastructure;
+using Game.EventBus;
 
 namespace Game.Domain
 {

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Unity.Collections;
 using Unity.Networking.Transport;
 using Game.Presentation;
+using Game.EventBus;
 using UnityEngine;
 
 namespace Game.Infrastructure

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
@@ -4,6 +4,7 @@ using Game.Domain.Events;
 using Game.Networking;
 using Game.Networking.Messages;
 using Game.Utils;
+using Game.EventBus;
 using UnityEngine;
 using UnityEngine.InputSystem;
 

--- a/CodexTest/Assets/Scripts/Infrastructure/EventBus/EventBus.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/EventBus/EventBus.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Game.Infrastructure
+namespace Game.EventBus
 {
     /// <summary>
     /// Simple event bus for decoupled communication between systems.

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
@@ -8,6 +8,7 @@ using Game.Systems;
 using Game.Utils;
 using System.Collections.Generic;
 using Unity.Networking.Transport;
+using Game.EventBus;
 using UnityEngine;
 
 namespace Game.Infrastructure

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
@@ -9,6 +9,7 @@ using Game.Domain.Commands;
 using Game.Domain.ECS;
 using Game.Networking;
 using Game.Networking.Messages;
+using Game.EventBus;
 
 namespace Game.Infrastructure
 {

--- a/CodexTest/Assets/Scripts/Infrastructure/StatsSnapshotReceiver.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/StatsSnapshotReceiver.cs
@@ -1,7 +1,7 @@
 using System.Text;
 using Game.Domain.Events;
 using Game.Domain.ECS;
-using Game.Infrastructure;
+using Game.EventBus;
 using Game.Networking;
 using Game.Networking.Messages;
 using Unity.Collections;

--- a/CodexTest/Assets/Scripts/Presentation/SurvivalUI.cs
+++ b/CodexTest/Assets/Scripts/Presentation/SurvivalUI.cs
@@ -1,5 +1,5 @@
 using Game.Domain.Events;
-using Game.Infrastructure;
+using Game.EventBus;
 using UnityEngine;
 using UnityEngine.UI;
 

--- a/CodexTest/Assets/Scripts/Systems/JumpSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/JumpSystem.cs
@@ -2,7 +2,7 @@ using Game.Components;
 using Game.Domain.Commands;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using Game.Infrastructure;
+using Game.EventBus;
 using System.Linq;
 using UnityEngine;
 

--- a/CodexTest/Assets/Scripts/Systems/MovementSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/MovementSystem.cs
@@ -2,7 +2,7 @@ using Game.Components;
 using Game.Domain.Commands;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using Game.Infrastructure;
+using Game.EventBus;
 using UnityEngine;
 
 namespace Game.Systems

--- a/CodexTest/Assets/Scripts/Systems/ReplicationSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/ReplicationSystem.cs
@@ -2,7 +2,7 @@ using Game.Domain.ECS;
 using Game.Domain.Events;
 using Game.Networking;
 using Game.Networking.Messages;
-using Game.Infrastructure;
+using Game.EventBus;
 using UnityEngine;
 
 namespace Game.Systems

--- a/CodexTest/Assets/Scripts/Systems/SurvivalReplicationSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/SurvivalReplicationSystem.cs
@@ -2,7 +2,7 @@ using Game.Domain.ECS;
 using Game.Domain.Events;
 using Game.Networking;
 using Game.Networking.Messages;
-using Game.Infrastructure;
+using Game.EventBus;
 using UnityEngine;
 
 namespace Game.Systems

--- a/CodexTest/Assets/Scripts/Systems/SurvivalSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/SurvivalSystem.cs
@@ -1,7 +1,7 @@
 using Game.Components;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using Game.Infrastructure;
+using Game.EventBus;
 using System.Linq;
 using UnityEngine;
 

--- a/CodexTest/Assets/Tests/CommandHandlerTests.cs
+++ b/CodexTest/Assets/Tests/CommandHandlerTests.cs
@@ -1,7 +1,7 @@
 using Game.Domain;
 using Game.Domain.Commands;
 using Game.Domain.ECS;
-using Game.Infrastructure;
+using Game.EventBus;
 using NUnit.Framework;
 using UnityEngine;
 

--- a/CodexTest/Assets/Tests/JumpSystemTests.cs
+++ b/CodexTest/Assets/Tests/JumpSystemTests.cs
@@ -3,7 +3,7 @@ using Game.Components;
 using Game.Domain.Commands;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using Game.Infrastructure;
+using Game.EventBus;
 using Game.Systems;
 using NUnit.Framework;
 using UnityEngine;

--- a/CodexTest/Assets/Tests/MovementSystemTests.cs
+++ b/CodexTest/Assets/Tests/MovementSystemTests.cs
@@ -3,7 +3,7 @@ using Game.Components;
 using Game.Domain.Commands;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using Game.Infrastructure;
+using Game.EventBus;
 using Game.Systems;
 using NUnit.Framework;
 using UnityEngine;

--- a/CodexTest/Assets/Tests/ReplicationSystemTests.cs
+++ b/CodexTest/Assets/Tests/ReplicationSystemTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using Game.Infrastructure;
+using Game.EventBus;
 using Game.Networking;
 using Game.Networking.Messages;
 using Game.Systems;

--- a/CodexTest/Assets/Tests/SurvivalReplicationSystemTests.cs
+++ b/CodexTest/Assets/Tests/SurvivalReplicationSystemTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using Game.Infrastructure;
+using Game.EventBus;
 using Game.Networking;
 using Game.Networking.Messages;
 using Game.Systems;

--- a/CodexTest/Assets/Tests/SurvivalSystemTests.cs
+++ b/CodexTest/Assets/Tests/SurvivalSystemTests.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using Game.Components;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using Game.Infrastructure;
+using Game.EventBus;
 using Game.Systems;
 using NUnit.Framework;
 


### PR DESCRIPTION
## Summary
- move EventBus to `Game.EventBus` namespace
- update command handler, systems, infrastructure, and tests to import `Game.EventBus`

## Testing
- `unity-editor -quit -batchmode -projectPath . -runTests -testResults /tmp/testresults.xml` *(fails: command not found)*
- `rg "using Game\.Infrastructure;" -n`


------
https://chatgpt.com/codex/tasks/task_e_689db8c4acf883219916a4f1bfa5d7c9