### PR TITLE
Use EventBus alias

### DIFF
--- a/CodexTest/Assets/Scripts/Domain/CommandHandler.cs
+++ b/CodexTest/Assets/Scripts/Domain/CommandHandler.cs
@@ -1,5 +1,5 @@
 using Game.Domain.Commands;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 
 namespace Game.Domain
 {

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
@@ -5,7 +5,7 @@ using System.Text;
 using Unity.Collections;
 using Unity.Networking.Transport;
 using Game.Presentation;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 using UnityEngine;
 
 namespace Game.Infrastructure

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
@@ -4,7 +4,7 @@ using Game.Domain.Events;
 using Game.Networking;
 using Game.Networking.Messages;
 using Game.Utils;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 using UnityEngine;
 using UnityEngine.InputSystem;
 

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
@@ -8,7 +8,7 @@ using Game.Systems;
 using Game.Utils;
 using System.Collections.Generic;
 using Unity.Networking.Transport;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 using UnityEngine;
 
 namespace Game.Infrastructure

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
@@ -9,7 +9,7 @@ using Game.Domain.Commands;
 using Game.Domain.ECS;
 using Game.Networking;
 using Game.Networking.Messages;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 
 namespace Game.Infrastructure
 {

--- a/CodexTest/Assets/Scripts/Infrastructure/StatsSnapshotReceiver.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/StatsSnapshotReceiver.cs
@@ -1,7 +1,7 @@
 using System.Text;
 using Game.Domain.Events;
 using Game.Domain.ECS;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 using Game.Networking;
 using Game.Networking.Messages;
 using Unity.Collections;

--- a/CodexTest/Assets/Scripts/Presentation/SurvivalUI.cs
+++ b/CodexTest/Assets/Scripts/Presentation/SurvivalUI.cs
@@ -1,5 +1,5 @@
 using Game.Domain.Events;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 using UnityEngine;
 using UnityEngine.UI;
 

--- a/CodexTest/Assets/Scripts/Systems/JumpSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/JumpSystem.cs
@@ -2,7 +2,7 @@ using Game.Components;
 using Game.Domain.Commands;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 using System.Linq;
 using UnityEngine;
 

--- a/CodexTest/Assets/Scripts/Systems/MovementSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/MovementSystem.cs
@@ -2,7 +2,7 @@ using Game.Components;
 using Game.Domain.Commands;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 using UnityEngine;
 
 namespace Game.Systems

--- a/CodexTest/Assets/Scripts/Systems/ReplicationSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/ReplicationSystem.cs
@@ -2,7 +2,7 @@ using Game.Domain.ECS;
 using Game.Domain.Events;
 using Game.Networking;
 using Game.Networking.Messages;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 using UnityEngine;
 
 namespace Game.Systems

--- a/CodexTest/Assets/Scripts/Systems/SurvivalReplicationSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/SurvivalReplicationSystem.cs
@@ -2,7 +2,7 @@ using Game.Domain.ECS;
 using Game.Domain.Events;
 using Game.Networking;
 using Game.Networking.Messages;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 using UnityEngine;
 
 namespace Game.Systems

--- a/CodexTest/Assets/Scripts/Systems/SurvivalSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/SurvivalSystem.cs
@@ -1,7 +1,7 @@
 using Game.Components;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 using System.Linq;
 using UnityEngine;
 

--- a/CodexTest/Assets/Tests/CommandHandlerTests.cs
+++ b/CodexTest/Assets/Tests/CommandHandlerTests.cs
@@ -1,7 +1,7 @@
 using Game.Domain;
 using Game.Domain.Commands;
 using Game.Domain.ECS;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 using NUnit.Framework;
 using UnityEngine;
 

--- a/CodexTest/Assets/Tests/JumpSystemTests.cs
+++ b/CodexTest/Assets/Tests/JumpSystemTests.cs
@@ -3,7 +3,7 @@ using Game.Components;
 using Game.Domain.Commands;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 using Game.Systems;
 using NUnit.Framework;
 using UnityEngine;

--- a/CodexTest/Assets/Tests/MovementSystemTests.cs
+++ b/CodexTest/Assets/Tests/MovementSystemTests.cs
@@ -3,7 +3,7 @@ using Game.Components;
 using Game.Domain.Commands;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 using Game.Systems;
 using NUnit.Framework;
 using UnityEngine;

--- a/CodexTest/Assets/Tests/ReplicationSystemTests.cs
+++ b/CodexTest/Assets/Tests/ReplicationSystemTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 using Game.Networking;
 using Game.Networking.Messages;
 using Game.Systems;

--- a/CodexTest/Assets/Tests/SurvivalReplicationSystemTests.cs
+++ b/CodexTest/Assets/Tests/SurvivalReplicationSystemTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 using Game.Networking;
 using Game.Networking.Messages;
 using Game.Systems;

--- a/CodexTest/Assets/Tests/SurvivalSystemTests.cs
+++ b/CodexTest/Assets/Tests/SurvivalSystemTests.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using Game.Components;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using Game.EventBus;
+using EventBus = Game.EventBus.EventBus;
 using Game.Systems;
 using NUnit.Framework;
 


### PR DESCRIPTION
## Summary
- replace namespace import with EventBus alias across domain, systems, infrastructure, and tests

## Testing
- `csc` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dbb45a63c8321b32ad8176c61b974