### PR TITLE
refactor: disambiguate event bus alias

### DIFF
--- a/CodexTest/Assets/Scripts/Domain/CommandHandler.cs
+++ b/CodexTest/Assets/Scripts/Domain/CommandHandler.cs
@@ -1,5 +1,5 @@
 using Game.Domain.Commands;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 
 namespace Game.Domain
 {
@@ -8,9 +8,9 @@ namespace Game.Domain
     /// </summary>
     public class CommandHandler
     {
-        private readonly EventBus _eventBus;
+        private readonly GameEventBus _eventBus;
 
-        public CommandHandler(EventBus eventBus)
+        public CommandHandler(GameEventBus eventBus)
         {
             _eventBus = eventBus;
         }

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
@@ -5,7 +5,7 @@ using System.Text;
 using Unity.Collections;
 using Unity.Networking.Transport;
 using Game.Presentation;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 using UnityEngine;
 
 namespace Game.Infrastructure
@@ -26,7 +26,7 @@ namespace Game.Infrastructure
         [SerializeField] private NetworkLatencyLogger latencyLogger;
 
         private NetworkManager networkManager;
-        private EventBus eventBus;
+        private GameEventBus eventBus;
         private bool playerInitialized;
 
         private void Awake()
@@ -60,7 +60,7 @@ namespace Game.Infrastructure
 
         private void Start()
         {
-            eventBus = new EventBus();
+            eventBus = new GameEventBus();
             networkManager = new NetworkManager();
             networkManager.StartClient(address, port);
             networkManager.OnData += OnDataReceived;

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
@@ -4,7 +4,7 @@ using Game.Domain.Events;
 using Game.Networking;
 using Game.Networking.Messages;
 using Game.Utils;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -16,7 +16,7 @@ namespace Game.Infrastructure
     public class ClientInputSender : MonoBehaviour
     {
         private NetworkManager networkManager;
-        private EventBus eventBus;
+        private GameEventBus eventBus;
         private float walkSpeed;
         private float runSpeed;
         [SerializeField] private float jumpForce = 5f;
@@ -32,7 +32,7 @@ namespace Game.Infrastructure
         /// <summary>
         /// Injects dependencies from ClientBootstrap.
         /// </summary>
-        public void Initialize(NetworkManager manager, EventBus eventBus, Entity playerEntity, Transform target, float walkSpeed, float runSpeed, float jumpForce, float gravity)
+        public void Initialize(NetworkManager manager, GameEventBus eventBus, Entity playerEntity, Transform target, float walkSpeed, float runSpeed, float jumpForce, float gravity)
         {
             networkManager = manager;
             this.eventBus = eventBus;

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
@@ -8,7 +8,7 @@ using Game.Systems;
 using Game.Utils;
 using System.Collections.Generic;
 using Unity.Networking.Transport;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 using UnityEngine;
 
 namespace Game.Infrastructure
@@ -23,7 +23,7 @@ namespace Game.Infrastructure
         [SerializeField] private MovementConfig movementConfig;
 
         private World world;
-        private EventBus eventBus;
+        private GameEventBus eventBus;
         private NetworkManager networkManager;
         private MovementSystem movementSystem;
         private ReplicationSystem replicationSystem;
@@ -40,7 +40,7 @@ namespace Game.Infrastructure
 
         private void Start()
         {
-            eventBus = new EventBus();
+            eventBus = new GameEventBus();
             world = new World();
             networkManager = new NetworkManager();
             networkManager.StartServer(port);

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
@@ -9,7 +9,7 @@ using Game.Domain.Commands;
 using Game.Domain.ECS;
 using Game.Networking;
 using Game.Networking.Messages;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 
 namespace Game.Infrastructure
 {
@@ -19,14 +19,14 @@ namespace Game.Infrastructure
     public class ServerCommandDispatcher : IDisposable
     {
         private readonly NetworkManager _networkManager;
-        private readonly EventBus _eventBus;
+        private readonly GameEventBus _eventBus;
         private readonly Dictionary<NetworkConnection, Entity> _connectionToEntity;
         private readonly Dictionary<MessageType, Action<NetworkConnection, string>> _handlers = new();
 
 
         public ServerCommandDispatcher(
             NetworkManager networkManager,
-            EventBus eventBus,
+            GameEventBus eventBus,
             Dictionary<NetworkConnection, Entity> connectionToEntity)
         {
             _networkManager = networkManager;

--- a/CodexTest/Assets/Scripts/Infrastructure/StatsSnapshotReceiver.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/StatsSnapshotReceiver.cs
@@ -1,7 +1,7 @@
 using System.Text;
 using Game.Domain.Events;
 using Game.Domain.ECS;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 using Game.Networking;
 using Game.Networking.Messages;
 using Unity.Collections;
@@ -16,10 +16,10 @@ namespace Game.Infrastructure
     public class StatsSnapshotReceiver : MonoBehaviour
     {
         private NetworkManager _networkManager;
-        private EventBus _eventBus;
+        private GameEventBus _eventBus;
         private int _playerEntityId;
 
-        public void Initialize(NetworkManager manager, EventBus eventBus, Entity player)
+        public void Initialize(NetworkManager manager, GameEventBus eventBus, Entity player)
         {
             _networkManager = manager;
             _eventBus = eventBus;

--- a/CodexTest/Assets/Scripts/Presentation/SurvivalUI.cs
+++ b/CodexTest/Assets/Scripts/Presentation/SurvivalUI.cs
@@ -1,5 +1,5 @@
 using Game.Domain.Events;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -13,9 +13,9 @@ namespace Game.Presentation
         [SerializeField] private Slider hungerBar;
         [SerializeField] private Slider staminaBar;
 
-        private EventBus _eventBus;
+        private GameEventBus _eventBus;
 
-        public void Initialize(EventBus eventBus)
+        public void Initialize(GameEventBus eventBus)
         {
             _eventBus = eventBus;
             _eventBus.Subscribe<HungerChangedEvent>(OnHungerChanged);

--- a/CodexTest/Assets/Scripts/Systems/JumpSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/JumpSystem.cs
@@ -2,7 +2,7 @@ using Game.Components;
 using Game.Domain.Commands;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 using System.Linq;
 using UnityEngine;
 
@@ -14,10 +14,10 @@ namespace Game.Systems
     public class JumpSystem : ISystem
     {
         private readonly World _world;
-        private readonly EventBus _eventBus;
+        private readonly GameEventBus _eventBus;
         private float _fixedDeltaTime;
 
-        public JumpSystem(World world, EventBus eventBus)
+        public JumpSystem(World world, GameEventBus eventBus)
         {
             _world = world;
             _eventBus = eventBus;

--- a/CodexTest/Assets/Scripts/Systems/MovementSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/MovementSystem.cs
@@ -2,7 +2,7 @@ using Game.Components;
 using Game.Domain.Commands;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 using UnityEngine;
 
 namespace Game.Systems
@@ -13,10 +13,10 @@ namespace Game.Systems
     public class MovementSystem : ISystem
     {
         private readonly World _world;
-        private readonly EventBus _eventBus;
+        private readonly GameEventBus _eventBus;
         private float _fixedDeltaTime;
 
-        public MovementSystem(World world, EventBus eventBus)
+        public MovementSystem(World world, GameEventBus eventBus)
         {
             _world = world;
             _eventBus = eventBus;

--- a/CodexTest/Assets/Scripts/Systems/ReplicationSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/ReplicationSystem.cs
@@ -2,7 +2,7 @@ using Game.Domain.ECS;
 using Game.Domain.Events;
 using Game.Networking;
 using Game.Networking.Messages;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 using UnityEngine;
 
 namespace Game.Systems
@@ -13,9 +13,9 @@ namespace Game.Systems
     public class ReplicationSystem : ISystem
     {
         private readonly NetworkManager _networkManager;
-        private readonly EventBus _eventBus;
+        private readonly GameEventBus _eventBus;
 
-        public ReplicationSystem(NetworkManager networkManager, EventBus eventBus)
+        public ReplicationSystem(NetworkManager networkManager, GameEventBus eventBus)
         {
             _networkManager = networkManager;
             _eventBus = eventBus;

--- a/CodexTest/Assets/Scripts/Systems/SurvivalReplicationSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/SurvivalReplicationSystem.cs
@@ -2,7 +2,7 @@ using Game.Domain.ECS;
 using Game.Domain.Events;
 using Game.Networking;
 using Game.Networking.Messages;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 using UnityEngine;
 
 namespace Game.Systems
@@ -13,9 +13,9 @@ namespace Game.Systems
     public class SurvivalReplicationSystem : ISystem
     {
         private readonly NetworkManager _networkManager;
-        private readonly EventBus _eventBus;
+        private readonly GameEventBus _eventBus;
 
-        public SurvivalReplicationSystem(NetworkManager networkManager, EventBus eventBus)
+        public SurvivalReplicationSystem(NetworkManager networkManager, GameEventBus eventBus)
         {
             _networkManager = networkManager;
             _eventBus = eventBus;

--- a/CodexTest/Assets/Scripts/Systems/SurvivalSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/SurvivalSystem.cs
@@ -1,7 +1,7 @@
 using Game.Components;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 using System.Linq;
 using UnityEngine;
 
@@ -13,10 +13,10 @@ namespace Game.Systems
     public class SurvivalSystem : ISystem
     {
         private readonly World _world;
-        private readonly EventBus _eventBus;
+        private readonly GameEventBus _eventBus;
         private float _fixedDeltaTime;
 
-        public SurvivalSystem(World world, EventBus eventBus)
+        public SurvivalSystem(World world, GameEventBus eventBus)
         {
             _world = world;
             _eventBus = eventBus;

--- a/CodexTest/Assets/Tests/CommandHandlerTests.cs
+++ b/CodexTest/Assets/Tests/CommandHandlerTests.cs
@@ -1,7 +1,7 @@
 using Game.Domain;
 using Game.Domain.Commands;
 using Game.Domain.ECS;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -12,7 +12,7 @@ namespace Tests
         [Test]
         public void HandleMoveCommand_PublishesCommand()
         {
-            var eventBus = new EventBus();
+            var eventBus = new GameEventBus();
             var handler = new CommandHandler(eventBus);
             MoveCommand received = default;
             eventBus.Subscribe<MoveCommand>(cmd => received = cmd);
@@ -27,7 +27,7 @@ namespace Tests
         [Test]
         public void HandleJumpCommand_PublishesCommand()
         {
-            var eventBus = new EventBus();
+            var eventBus = new GameEventBus();
             var handler = new CommandHandler(eventBus);
             JumpCommand received = default;
             eventBus.Subscribe<JumpCommand>(cmd => received = cmd);

--- a/CodexTest/Assets/Tests/JumpSystemTests.cs
+++ b/CodexTest/Assets/Tests/JumpSystemTests.cs
@@ -3,7 +3,7 @@ using Game.Components;
 using Game.Domain.Commands;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 using Game.Systems;
 using NUnit.Framework;
 using UnityEngine;
@@ -16,7 +16,7 @@ namespace Tests
         public void JumpCommandAddsVerticalVelocity()
         {
             var world = new World();
-            var eventBus = new EventBus();
+            var eventBus = new GameEventBus();
             var system = new JumpSystem(world, eventBus);
             var entity = world.CreateEntity();
             world.AddComponent(entity, new PositionComponent { Value = Vector3.zero });
@@ -32,7 +32,7 @@ namespace Tests
         public void UpdateIntegratesGravityAndLanding()
         {
             var world = new World();
-            var eventBus = new EventBus();
+            var eventBus = new GameEventBus();
             var system = new JumpSystem(world, eventBus);
             var entity = world.CreateEntity();
             world.AddComponent(entity, new PositionComponent { Value = Vector3.zero });

--- a/CodexTest/Assets/Tests/MovementSystemTests.cs
+++ b/CodexTest/Assets/Tests/MovementSystemTests.cs
@@ -3,7 +3,7 @@ using Game.Components;
 using Game.Domain.Commands;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 using Game.Systems;
 using NUnit.Framework;
 using UnityEngine;
@@ -16,7 +16,7 @@ namespace Tests
         public void MoveCommandUpdatesPositionAndState()
         {
             var world = new World();
-            var eventBus = new EventBus();
+            var eventBus = new GameEventBus();
             var system = new MovementSystem(world, eventBus);
             var entity = world.CreateEntity();
             world.AddComponent(entity, new PositionComponent { Value = Vector3.zero });
@@ -41,7 +41,7 @@ namespace Tests
         public void MoveCommandWithoutStaminaFallsBackToWalk()
         {
             var world = new World();
-            var eventBus = new EventBus();
+            var eventBus = new GameEventBus();
             var system = new MovementSystem(world, eventBus);
             var entity = world.CreateEntity();
             world.AddComponent(entity, new PositionComponent { Value = Vector3.zero });

--- a/CodexTest/Assets/Tests/ReplicationSystemTests.cs
+++ b/CodexTest/Assets/Tests/ReplicationSystemTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 using Game.Networking;
 using Game.Networking.Messages;
 using Game.Systems;
@@ -28,7 +28,7 @@ namespace Tests
         public void PositionChangedEvent_SendsSnapshotMessage()
         {
             var network = new TestNetworkManager();
-            var eventBus = new EventBus();
+            var eventBus = new GameEventBus();
             var system = new ReplicationSystem(network, eventBus);
 
             var entity = new Entity(42);

--- a/CodexTest/Assets/Tests/SurvivalReplicationSystemTests.cs
+++ b/CodexTest/Assets/Tests/SurvivalReplicationSystemTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 using Game.Networking;
 using Game.Networking.Messages;
 using Game.Systems;
@@ -28,7 +28,7 @@ namespace Tests
         public void StaminaChangedEvent_SendsSnapshotMessage()
         {
             var network = new TestNetworkManager();
-            var eventBus = new EventBus();
+            var eventBus = new GameEventBus();
             var system = new SurvivalReplicationSystem(network, eventBus);
 
             var entity = new Entity(10);
@@ -47,7 +47,7 @@ namespace Tests
         public void HungerChangedEvent_SendsSnapshotMessage()
         {
             var network = new TestNetworkManager();
-            var eventBus = new EventBus();
+            var eventBus = new GameEventBus();
             var system = new SurvivalReplicationSystem(network, eventBus);
 
             var entity = new Entity(11);

--- a/CodexTest/Assets/Tests/SurvivalSystemTests.cs
+++ b/CodexTest/Assets/Tests/SurvivalSystemTests.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using Game.Components;
 using Game.Domain.ECS;
 using Game.Domain.Events;
-using EventBus = Game.EventBus.EventBus;
+using GameEventBus = Game.EventBus.EventBus;
 using Game.Systems;
 using NUnit.Framework;
 
@@ -14,7 +14,7 @@ namespace Tests
         public void RunningDrainsStaminaAndStopsWhenEmpty()
         {
             var world = new World();
-            var eventBus = new EventBus();
+            var eventBus = new GameEventBus();
             var system = new SurvivalSystem(world, eventBus);
             var entity = world.CreateEntity();
             world.AddComponent(entity, new StaminaComponent { Current = 2f, Max = 5f, DrainPerSecond = 1f, RegenPerSecond = 1f });
@@ -34,7 +34,7 @@ namespace Tests
         public void StaminaRegeneratesWhenNotRunning()
         {
             var world = new World();
-            var eventBus = new EventBus();
+            var eventBus = new GameEventBus();
             var system = new SurvivalSystem(world, eventBus);
             var entity = world.CreateEntity();
             world.AddComponent(entity, new StaminaComponent { Current = 0f, Max = 5f, DrainPerSecond = 1f, RegenPerSecond = 2f });
@@ -51,7 +51,7 @@ namespace Tests
         public void HungerDecreasesOverTime()
         {
             var world = new World();
-            var eventBus = new EventBus();
+            var eventBus = new GameEventBus();
             var system = new SurvivalSystem(world, eventBus);
             var entity = world.CreateEntity();
             world.AddComponent(entity, new HungerComponent { Current = 5f, Max = 5f, DrainPerSecond = 1f });


### PR DESCRIPTION
## Summary
- alias Game.EventBus.EventBus as GameEventBus to avoid namespace clashes
- update all fields, parameters, and tests to use GameEventBus

## Testing
- `csc -target:library $(find Assets -name '*.cs') -out:/tmp/test.dll` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689dbdfd43648321ab23ff1b8d791e73