### PR TITLE
Add Unity Transport references to networking assembly

### DIFF
--- a/CodexTest/Assets/Scripts/Networking/Networking.asmdef
+++ b/CodexTest/Assets/Scripts/Networking/Networking.asmdef
@@ -1,7 +1,9 @@
 {
   "name": "Game.Networking",
   "references": [
-    "Game.Domain"
+    "Game.Domain",
+    "Unity.Transport",
+    "Unity.Collections"
   ],
   "includePlatforms": [],
   "excludePlatforms": [],


### PR DESCRIPTION
## Summary
- include Unity.Transport and Unity.Collections assemblies in networking asmdef

## Testing
- `csc Assets/Scripts/Networking/NetworkManager.cs` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689dc115103c83219c73cc99598558d3