### PR TITLE
Update Unity Transport to 2.5.3 and migrate networking API

### DIFF
--- a/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
@@ -70,7 +70,7 @@ namespace Game.Infrastructure
             }
         }
 
-        private void OnDataReceived(NetworkDriver.Connection connection, DataStreamReader stream)
+        private void OnDataReceived(NetworkConnection connection, DataStreamReader stream)
         {
             using var bytes = new NativeArray<byte>(stream.Length, Allocator.Temp);
             stream.ReadBytes(bytes);

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientSnapshotReceiver.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientSnapshotReceiver.cs
@@ -28,7 +28,7 @@ namespace Game.Infrastructure
             _entities[entityId] = transform;
         }
 
-        private void OnDataReceived(NetworkDriver.Connection connection, DataStreamReader stream)
+        private void OnDataReceived(NetworkConnection connection, DataStreamReader stream)
         {
             using var bytes = new NativeArray<byte>(stream.Length, Allocator.Temp);
             stream.ReadBytes(bytes);

--- a/CodexTest/Assets/Scripts/Infrastructure/NetworkLatencyLogger.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/NetworkLatencyLogger.cs
@@ -47,7 +47,7 @@ namespace Game.Infrastructure
             }
         }
 
-        private void OnDataReceived(NetworkDriver.Connection connection, DataStreamReader stream)
+        private void OnDataReceived(NetworkConnection connection, DataStreamReader stream)
         {
             using var bytes = new NativeArray<byte>(stream.Length, Allocator.Temp);
             stream.ReadBytes(bytes);

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
@@ -32,7 +32,7 @@ namespace Game.Infrastructure
         private SurvivalReplicationSystem survivalReplicationSystem;
         private ServerCommandDispatcher dispatcher;
         private CommandHandler commandHandler;
-        private Dictionary<NetworkDriver.Connection, Entity> connectionToEntity;
+        private Dictionary<NetworkConnection, Entity> connectionToEntity;
         private float tickAccumulator;
         private float fixedDeltaTime;
 
@@ -52,7 +52,7 @@ namespace Game.Infrastructure
             {
                 movementConfig = ScriptableObject.CreateInstance<MovementConfig>();
             }
-            connectionToEntity = new Dictionary<NetworkDriver.Connection, Entity>();
+            connectionToEntity = new Dictionary<NetworkConnection, Entity>();
             networkManager.OnClientConnected += OnClientConnected;
             networkManager.OnClientDisconnected += OnClientDisconnected;
             dispatcher = new ServerCommandDispatcher(networkManager, eventBus, connectionToEntity);
@@ -66,7 +66,7 @@ namespace Game.Infrastructure
             _initialized = true;
         }
 
-        private void OnClientConnected(NetworkDriver.Connection connection)
+        private void OnClientConnected(NetworkConnection connection)
         {
             var entity = world.CreateEntity();
             world.AddComponent(entity, new PositionComponent { Value = Vector3.zero });
@@ -106,7 +106,7 @@ namespace Game.Infrastructure
             networkManager.SendMessage(connection, message);
         }
 
-        private void OnClientDisconnected(NetworkDriver.Connection connection)
+        private void OnClientDisconnected(NetworkConnection connection)
         {
             connectionToEntity.Remove(connection);
         }

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerCommandDispatcher.cs
@@ -20,14 +20,14 @@ namespace Game.Infrastructure
     {
         private readonly NetworkManager _networkManager;
         private readonly GameEventBus _eventBus;
-        private readonly Dictionary<NetworkDriver.Connection, Entity> _connectionToEntity;
-        private readonly Dictionary<MessageType, Action<NetworkDriver.Connection, string>> _handlers = new();
+        private readonly Dictionary<NetworkConnection, Entity> _connectionToEntity;
+        private readonly Dictionary<MessageType, Action<NetworkConnection, string>> _handlers = new();
 
 
         public ServerCommandDispatcher(
             NetworkManager networkManager,
             GameEventBus eventBus,
-            Dictionary<NetworkDriver.Connection, Entity> connectionToEntity)
+            Dictionary<NetworkConnection, Entity> connectionToEntity)
         {
             _networkManager = networkManager;
             _eventBus = eventBus;
@@ -62,7 +62,7 @@ namespace Game.Infrastructure
             };
         }
 
-        private void OnDataReceived(NetworkDriver.Connection connection, DataStreamReader stream)
+        private void OnDataReceived(NetworkConnection connection, DataStreamReader stream)
         {
             using var bytes = new NativeArray<byte>(stream.Length, Allocator.Temp);
             stream.ReadBytes(bytes);

--- a/CodexTest/Assets/Scripts/Infrastructure/StatsSnapshotReceiver.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/StatsSnapshotReceiver.cs
@@ -27,7 +27,7 @@ namespace Game.Infrastructure
             _networkManager.OnData += OnDataReceived;
         }
 
-        private void OnDataReceived(NetworkDriver.Connection connection, DataStreamReader stream)
+        private void OnDataReceived(NetworkConnection connection, DataStreamReader stream)
         {
             using var bytes = new NativeArray<byte>(stream.Length, Allocator.Temp);
             stream.ReadBytes(bytes);

--- a/CodexTest/Assets/Scripts/Networking/NetworkManager.cs
+++ b/CodexTest/Assets/Scripts/Networking/NetworkManager.cs
@@ -13,12 +13,12 @@ namespace Game.Networking
     public class NetworkManager : IDisposable
     {
         private NetworkDriver _driver;
-        private NativeList<NetworkDriver.Connection> _connections;
+        private NativeList<NetworkConnection> _connections;
         public bool IsServer { get; private set; }
 
-        public event Action<NetworkDriver.Connection> OnClientConnected;
-        public event Action<NetworkDriver.Connection> OnClientDisconnected;
-        public event Action<NetworkDriver.Connection, DataStreamReader> OnData;
+        public event Action<NetworkConnection> OnClientConnected;
+        public event Action<NetworkConnection> OnClientDisconnected;
+        public event Action<NetworkConnection, DataStreamReader> OnData;
         /// <summary>
         /// Indicates whether a connection is currently established.
         /// </summary>
@@ -29,7 +29,7 @@ namespace Game.Networking
         public void StartClient(string address, ushort port)
         {
             _driver = NetworkDriver.Create();
-            _connections = new NativeList<NetworkDriver.Connection>(1, Allocator.Persistent);
+            _connections = new NativeList<NetworkConnection>(1, Allocator.Persistent);
             var endpoint = NetworkEndpoint.Parse(address, port);
             var connection = _driver.Connect(endpoint);
             _connections.Add(connection);
@@ -39,7 +39,7 @@ namespace Game.Networking
         public void StartServer(ushort port)
         {
             _driver = NetworkDriver.Create();
-            _connections = new NativeList<NetworkDriver.Connection>(16, Allocator.Persistent);
+            _connections = new NativeList<NetworkConnection>(16, Allocator.Persistent);
             var endpoint = NetworkEndpoint.AnyIpv4;
             endpoint.Port = port;
             if (_driver.Bind(endpoint) != 0)
@@ -59,7 +59,7 @@ namespace Game.Networking
 
             if (IsServer)
             {
-                NetworkDriver.Connection connection;
+                NetworkConnection connection;
                 while ((connection = _driver.Accept()).IsCreated)
                 {
                     _connections.Add(connection);
@@ -95,7 +95,7 @@ namespace Game.Networking
             }
         }
 
-        private void SendBytes(NetworkDriver.Connection connection, byte[] bytes)
+        private void SendBytes(NetworkConnection connection, byte[] bytes)
         {
             if (!connection.IsCreated)
                 return;
@@ -126,7 +126,7 @@ namespace Game.Networking
             }
         }
 
-        public void SendMessage<T>(NetworkDriver.Connection connection, T message)
+        public void SendMessage<T>(NetworkConnection connection, T message)
         {
             var json = JsonUtility.ToJson(message);
             SendBytes(connection, Encoding.UTF8.GetBytes(json));

--- a/CodexTest/Packages/manifest.json
+++ b/CodexTest/Packages/manifest.json
@@ -7,7 +7,7 @@
     "com.unity.inputsystem": "1.7.0",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.7.6",
-    "com.unity.transport": "2.0.0",
+    "com.unity.transport": "2.5.3",
     "com.unity.ugui": "1.0.0",
     "com.unity.visualscripting": "1.9.4",
     "com.unity.modules.ai": "1.0.0",


### PR DESCRIPTION
## Summary
- Upgrade Unity Transport to 2.5.3
- Replace deprecated `NetworkDriver.Connection` usages with `NetworkConnection`
- Adjust bootstraps and dispatchers for the new connection type

## Testing
- `unity-editor -batchmode -projectPath CodexTest -runTests -testResults results.xml -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc81767f4832183b4e1d4ba517d11