### PR TITLE
chore: update asmdef dependencies for Unity packages

### DIFF
--- a/CodexTest/Assets/Scripts/Infrastructure/Infrastructure.asmdef
+++ b/CodexTest/Assets/Scripts/Infrastructure/Infrastructure.asmdef
@@ -1,6 +1,16 @@
 {
   "name": "Game.Infrastructure",
-  "references": ["Game.Domain", "Game.Components", "Game.Systems", "Game.Networking", "Game.Utils", "Game.EventBus"],
+  "references": [
+    "Game.Domain",
+    "Game.Components",
+    "Game.Systems",
+    "Game.Networking",
+    "Game.Utils",
+    "Game.EventBus",
+    "Unity.Collections",
+    "Unity.Transport",
+    "Unity.InputSystem"
+  ],
   "includePlatforms": [],
   "excludePlatforms": [],
   "allowUnsafeCode": false,

--- a/CodexTest/Assets/Scripts/Networking/Networking.asmdef
+++ b/CodexTest/Assets/Scripts/Networking/Networking.asmdef
@@ -2,7 +2,10 @@
   "name": "Game.Networking",
   "references": [
     "Game.Domain",
-    "Unity.Collections"
+    "Unity.Collections",
+    "Unity.Transport",
+    "Unity.Transport.Utilities",
+    "Unity.Transport.Error"
   ],
   "includePlatforms": [],
   "excludePlatforms": [],


### PR DESCRIPTION
## Summary
- reference latest Unity Transport assemblies in networking
- allow infrastructure to use Unity Transport, Collections, and Input System

## Testing
- `unity-editor -batchmode -quit -projectPath . -runTests -testPlatform playmode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dd3affa288321956637c1e0824864