### PR TITLE
Abstract Unity Transport behind INetworkTransport

### DIFF
--- a/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientInputSender.cs
@@ -15,7 +15,7 @@ namespace Game.Infrastructure
     /// </summary>
     public class ClientInputSender : MonoBehaviour
     {
-        private NetworkManager networkManager;
+        private INetworkTransport networkManager;
         private GameEventBus eventBus;
         private float walkSpeed;
         private float runSpeed;
@@ -32,7 +32,7 @@ namespace Game.Infrastructure
         /// <summary>
         /// Injects dependencies from ClientBootstrap.
         /// </summary>
-        public void Initialize(NetworkManager manager, GameEventBus eventBus, Entity playerEntity, Transform target, float walkSpeed, float runSpeed, float jumpForce, float gravity)
+        public void Initialize(INetworkTransport manager, GameEventBus eventBus, Entity playerEntity, Transform target, float walkSpeed, float runSpeed, float jumpForce, float gravity)
         {
             networkManager = manager;
             this.eventBus = eventBus;

--- a/CodexTest/Assets/Scripts/Infrastructure/ClientSnapshotReceiver.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientSnapshotReceiver.cs
@@ -1,8 +1,6 @@
 using System.Text;
 using Game.Networking;
 using Game.Networking.Messages;
-using Unity.Collections;
-using Unity.Networking.Transport;
 using UnityEngine;
 
 namespace Game.Infrastructure
@@ -12,11 +10,11 @@ namespace Game.Infrastructure
     /// </summary>
     public class ClientSnapshotReceiver : MonoBehaviour
     {
-        private NetworkManager networkManager;
+        private INetworkTransport networkManager;
         private Transform entityPrefab;
         private readonly System.Collections.Generic.Dictionary<int, Transform> _entities = new();
 
-        public void Initialize(NetworkManager manager, Transform prefab)
+        public void Initialize(INetworkTransport manager, Transform prefab)
         {
             networkManager = manager;
             entityPrefab = prefab;
@@ -28,11 +26,9 @@ namespace Game.Infrastructure
             _entities[entityId] = transform;
         }
 
-        private void OnDataReceived(NetworkConnection connection, DataStreamReader stream)
+        private void OnDataReceived(int connectionId, byte[] data)
         {
-            using var bytes = new NativeArray<byte>(stream.Length, Allocator.Temp);
-            stream.ReadBytes(bytes);
-            var json = Encoding.UTF8.GetString(bytes.ToArray());
+            var json = Encoding.UTF8.GetString(data);
 
             var message = JsonUtility.FromJson<NetworkMessage>(json);
             if (message.Type != MessageType.PositionSnapshot)

--- a/CodexTest/Assets/Scripts/Networking/INetworkTransport.cs
+++ b/CodexTest/Assets/Scripts/Networking/INetworkTransport.cs
@@ -1,0 +1,73 @@
+using System;
+
+namespace Game.Networking
+{
+    /// <summary>
+    /// Abstraction over the underlying network transport implementation.
+    /// Provides a minimal set of operations required by the game logic.
+    /// </summary>
+    public interface INetworkTransport : IDisposable
+    {
+        /// <summary>
+        /// Fired when a client connects. The integer is a connection identifier.
+        /// </summary>
+        event Action<int> OnClientConnected;
+
+        /// <summary>
+        /// Fired when a client disconnects. The integer is a connection identifier.
+        /// </summary>
+        event Action<int> OnClientDisconnected;
+
+        /// <summary>
+        /// Fired when data is received from a connection.
+        /// The first integer is the connection identifier.
+        /// </summary>
+        event Action<int, byte[]> OnData;
+
+        /// <summary>
+        /// Indicates whether this instance is operating as a server.
+        /// </summary>
+        bool IsServer { get; }
+
+        /// <summary>
+        /// Indicates whether a connection is currently established.
+        /// </summary>
+        bool IsConnected { get; }
+
+        /// <summary>
+        /// Starts a client connection to the specified server address and port.
+        /// </summary>
+        void StartClient(string address, ushort port);
+
+        /// <summary>
+        /// Starts listening for client connections on the specified port.
+        /// </summary>
+        void StartServer(ushort port);
+
+        /// <summary>
+        /// Sends raw byte payload to all connected peers (or to the server when operating as a client).
+        /// </summary>
+        void SendBytes(byte[] bytes);
+
+        /// <summary>
+        /// Sends raw byte payload to a specific connection.
+        /// </summary>
+        void SendBytes(int connectionId, byte[] bytes);
+
+        /// <summary>
+        /// Serializes and sends the specified message to all connected peers.
+        /// </summary>
+        void SendMessage<T>(T message);
+
+        /// <summary>
+        /// Serializes and sends the specified message to a specific connection.
+        /// </summary>
+        void SendMessage<T>(int connectionId, T message);
+
+        /// <summary>
+        /// Processes incoming connections and network events.
+        /// </summary>
+        void Update();
+    }
+}
+

--- a/CodexTest/Assets/Scripts/Networking/INetworkTransport.cs.meta
+++ b/CodexTest/Assets/Scripts/Networking/INetworkTransport.cs.meta
@@ -1,11 +1,11 @@
 fileFormatVersion: 2
-guid: d29618ef21a502840bf3455495c298a8
+guid: 5984026d576649dd9b57d9f40d453d15
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Scripts/Systems/ReplicationSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/ReplicationSystem.cs
@@ -12,12 +12,12 @@ namespace Game.Systems
     /// </summary>
     public class ReplicationSystem : ISystem
     {
-        private readonly NetworkManager _networkManager;
+        private readonly INetworkTransport _transport;
         private readonly GameEventBus _eventBus;
 
-        public ReplicationSystem(NetworkManager networkManager, GameEventBus eventBus)
+        public ReplicationSystem(INetworkTransport transport, GameEventBus eventBus)
         {
-            _networkManager = networkManager;
+            _transport = transport;
             _eventBus = eventBus;
             _eventBus.Subscribe<PositionChangedEvent>(OnPositionChanged);
         }
@@ -32,7 +32,7 @@ namespace Game.Systems
             var snapshot = new PositionSnapshot(evt.Entity, evt.Position);
             var payload = JsonUtility.ToJson(snapshot);
             var message = new NetworkMessage(MessageType.PositionSnapshot, payload);
-            _networkManager.SendMessage(message);
+            _transport.SendMessage(message);
         }
     }
 }

--- a/CodexTest/Assets/Scripts/Systems/SurvivalReplicationSystem.cs
+++ b/CodexTest/Assets/Scripts/Systems/SurvivalReplicationSystem.cs
@@ -12,12 +12,12 @@ namespace Game.Systems
     /// </summary>
     public class SurvivalReplicationSystem : ISystem
     {
-        private readonly NetworkManager _networkManager;
+        private readonly INetworkTransport _transport;
         private readonly GameEventBus _eventBus;
 
-        public SurvivalReplicationSystem(NetworkManager networkManager, GameEventBus eventBus)
+        public SurvivalReplicationSystem(INetworkTransport transport, GameEventBus eventBus)
         {
-            _networkManager = networkManager;
+            _transport = transport;
             _eventBus = eventBus;
             _eventBus.Subscribe<StaminaChangedEvent>(OnStaminaChanged);
             _eventBus.Subscribe<HungerChangedEvent>(OnHungerChanged);
@@ -33,7 +33,7 @@ namespace Game.Systems
             var snapshot = new StaminaSnapshot(evt.Entity.Id, evt.Current, evt.Max);
             var payload = JsonUtility.ToJson(snapshot);
             var message = new NetworkMessage(MessageType.StaminaSnapshot, payload);
-            _networkManager.SendMessage(message);
+            _transport.SendMessage(message);
         }
 
         private void OnHungerChanged(HungerChangedEvent evt)
@@ -41,7 +41,7 @@ namespace Game.Systems
             var snapshot = new HungerSnapshot(evt.Entity.Id, evt.Current, evt.Max);
             var payload = JsonUtility.ToJson(snapshot);
             var message = new NetworkMessage(MessageType.HungerSnapshot, payload);
-            _networkManager.SendMessage(message);
+            _transport.SendMessage(message);
         }
     }
 }

--- a/CodexTest/Assets/Scripts/Transport/UnityTransportAdapter.cs.meta
+++ b/CodexTest/Assets/Scripts/Transport/UnityTransportAdapter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cabd371bd93146e89d4c7e3bce0263c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/CodexTest/Assets/Tests/ReplicationSystemTests.cs
+++ b/CodexTest/Assets/Tests/ReplicationSystemTests.cs
@@ -12,22 +12,40 @@ namespace Tests
 {
     public class ReplicationSystemTests
     {
-        private class TestNetworkManager : NetworkManager
+        private class FakeTransport : INetworkTransport
         {
             public readonly List<NetworkMessage> Sent = new();
-            public override void SendMessage<T>(T message)
+            public bool IsServer => false;
+            public bool IsConnected => true;
+            public event System.Action<int> OnClientConnected;
+            public event System.Action<int> OnClientDisconnected;
+            public event System.Action<int, byte[]> OnData;
+            public void StartClient(string address, ushort port) { }
+            public void StartServer(ushort port) { }
+            public void SendBytes(byte[] bytes) { }
+            public void SendBytes(int connectionId, byte[] bytes) { }
+            public void SendMessage<T>(T message)
             {
                 if (message is NetworkMessage nm)
                 {
                     Sent.Add(nm);
                 }
             }
+            public void SendMessage<T>(int connectionId, T message)
+            {
+                if (message is NetworkMessage nm)
+                {
+                    Sent.Add(nm);
+                }
+            }
+            public void Update() { }
+            public void Dispose() { }
         }
 
         [Test]
         public void PositionChangedEvent_SendsSnapshotMessage()
         {
-            var network = new TestNetworkManager();
+            var network = new FakeTransport();
             var eventBus = new GameEventBus();
             var system = new ReplicationSystem(network, eventBus);
 

--- a/CodexTest/Assets/Tests/SurvivalReplicationSystemTests.cs
+++ b/CodexTest/Assets/Tests/SurvivalReplicationSystemTests.cs
@@ -12,22 +12,40 @@ namespace Tests
 {
     public class SurvivalReplicationSystemTests
     {
-        private class TestNetworkManager : NetworkManager
+        private class FakeTransport : INetworkTransport
         {
             public readonly List<NetworkMessage> Sent = new();
-            public override void SendMessage<T>(T message)
+            public bool IsServer => false;
+            public bool IsConnected => true;
+            public event System.Action<int> OnClientConnected;
+            public event System.Action<int> OnClientDisconnected;
+            public event System.Action<int, byte[]> OnData;
+            public void StartClient(string address, ushort port) { }
+            public void StartServer(ushort port) { }
+            public void SendBytes(byte[] bytes) { }
+            public void SendBytes(int connectionId, byte[] bytes) { }
+            public void SendMessage<T>(T message)
             {
                 if (message is NetworkMessage nm)
                 {
                     Sent.Add(nm);
                 }
             }
+            public void SendMessage<T>(int connectionId, T message)
+            {
+                if (message is NetworkMessage nm)
+                {
+                    Sent.Add(nm);
+                }
+            }
+            public void Update() { }
+            public void Dispose() { }
         }
 
         [Test]
         public void StaminaChangedEvent_SendsSnapshotMessage()
         {
-            var network = new TestNetworkManager();
+            var network = new FakeTransport();
             var eventBus = new GameEventBus();
             var system = new SurvivalReplicationSystem(network, eventBus);
 
@@ -46,7 +64,7 @@ namespace Tests
         [Test]
         public void HungerChangedEvent_SendsSnapshotMessage()
         {
-            var network = new TestNetworkManager();
+            var network = new FakeTransport();
             var eventBus = new GameEventBus();
             var system = new SurvivalReplicationSystem(network, eventBus);
 


### PR DESCRIPTION
## Summary
- create INetworkTransport interface for decoupled networking
- add UnityTransportAdapter outside asmdef using Unity.Transport
- refactor systems, infrastructure, and tests to depend on INetworkTransport

## Testing
- `Tests not run - Unity editor not available`


------
https://chatgpt.com/codex/tasks/task_e_689dd606d93483219f13a5fde1ecb788