### PR TITLE
Decouple infrastructure from Unity Transport

### DIFF
--- a/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ClientBootstrap.cs
@@ -1,6 +1,5 @@
 using Game.Domain.ECS;
 using Game.Networking;
-using Game.Networking.Transport;
 using Game.Networking.Messages;
 using System.Text;
 using Game.Presentation;
@@ -24,6 +23,7 @@ namespace Game.Infrastructure
         [SerializeField] private SurvivalUI survivalUI;
         [SerializeField] private NetworkLatencyLogger latencyLogger;
 
+        [SerializeField] private MonoBehaviour transport;
         private INetworkTransport networkManager;
         private GameEventBus eventBus;
         private bool playerInitialized;
@@ -60,7 +60,13 @@ namespace Game.Infrastructure
         private void Start()
         {
             eventBus = new GameEventBus();
-            networkManager = new UnityTransportAdapter();
+            networkManager = transport as INetworkTransport;
+            if (networkManager == null)
+            {
+                Debug.LogError("Transport does not implement INetworkTransport");
+                enabled = false;
+                return;
+            }
             networkManager.StartClient(address, port);
             networkManager.OnData += OnDataReceived;
             if (latencyLogger != null)

--- a/CodexTest/Assets/Scripts/Infrastructure/Infrastructure.asmdef
+++ b/CodexTest/Assets/Scripts/Infrastructure/Infrastructure.asmdef
@@ -8,7 +8,6 @@
     "Game.Utils",
     "Game.EventBus",
     "Unity.Collections",
-    "Unity.Transport",
     "Unity.InputSystem"
   ],
   "includePlatforms": [],

--- a/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
+++ b/CodexTest/Assets/Scripts/Infrastructure/ServerBootstrap.cs
@@ -3,7 +3,6 @@ using Game.Domain;
 using Game.Domain.ECS;
 using Game.Domain.Events;
 using Game.Networking;
-using Game.Networking.Transport;
 using Game.Networking.Messages;
 using Game.Systems;
 using Game.Utils;
@@ -24,6 +23,7 @@ namespace Game.Infrastructure
 
         private World world;
         private GameEventBus eventBus;
+        [SerializeField] private MonoBehaviour transport;
         private INetworkTransport networkManager;
         private MovementSystem movementSystem;
         private ReplicationSystem replicationSystem;
@@ -42,7 +42,13 @@ namespace Game.Infrastructure
         {
             eventBus = new GameEventBus();
             world = new World();
-            networkManager = new UnityTransportAdapter();
+            networkManager = transport as INetworkTransport;
+            if (networkManager == null)
+            {
+                Debug.LogError("Transport does not implement INetworkTransport");
+                enabled = false;
+                return;
+            }
             networkManager.StartServer(port);
             if (survivalConfig == null)
             {

--- a/CodexTest/Assets/Scripts/Transport/UnityTransportAdapter.cs
+++ b/CodexTest/Assets/Scripts/Transport/UnityTransportAdapter.cs
@@ -13,7 +13,7 @@ namespace Game.Networking.Transport
     /// Adapter that wraps Unity.Transport and exposes it via the INetworkTransport interface.
     /// This file resides outside of any asmdef so it can directly reference Unity Transport types.
     /// </summary>
-    public class UnityTransportAdapter : INetworkTransport
+    public class UnityTransportAdapter : MonoBehaviour, INetworkTransport
     {
         private NetworkDriver _driver;
         private NativeList<NetworkConnection> _connections;
@@ -61,7 +61,7 @@ namespace Game.Networking.Transport
             IsServer = true;
         }
 
-        public void Update()
+        void INetworkTransport.Update()
         {
             if (!_driver.IsCreated)
                 return;
@@ -182,6 +182,11 @@ namespace Game.Networking.Transport
             {
                 _connections.Dispose();
             }
+        }
+
+        private void OnDestroy()
+        {
+            Dispose();
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove Unity.Transport from Infrastructure asmdef
- inject INetworkTransport via serialized field in bootstraps
- convert UnityTransportAdapter to MonoBehaviour and hide update logic behind interface

## Testing
- `unity -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dda8b8f608321bfa81485822461f5