### PR TITLE
Add presentation assembly and references

### DIFF
--- a/CodexTest/Assets/Scripts/Presentation/Game.Presentation.asmdef
+++ b/CodexTest/Assets/Scripts/Presentation/Game.Presentation.asmdef
@@ -1,15 +1,10 @@
 {
-  "name": "Game.Infrastructure",
+  "name": "Game.Presentation",
   "references": [
     "Game.Domain",
-    "Game.Components",
-    "Game.Systems",
-    "Game.Networking",
-    "Game.Utils",
     "Game.EventBus",
-    "Game.Presentation",
-    "Unity.Collections",
-    "Unity.InputSystem"
+    "UnityEngine.UI",
+    "Unity.TextMeshPro"
   ],
   "includePlatforms": [],
   "excludePlatforms": [],

--- a/CodexTest/Assets/Scripts/Presentation/Game.Presentation.asmdef.meta
+++ b/CodexTest/Assets/Scripts/Presentation/Game.Presentation.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a63d1b0c037f45c587d0edd5474e07a4
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CodexTest/Assets/Scripts/Presentation/PingDisplay.cs
+++ b/CodexTest/Assets/Scripts/Presentation/PingDisplay.cs
@@ -1,4 +1,3 @@
-using Game.Infrastructure;
 using TMPro;
 using UnityEngine;
 
@@ -11,25 +10,8 @@ namespace Game.Presentation
     public class PingDisplay : MonoBehaviour
     {
         [SerializeField] private TMP_Text pingText;
-        [SerializeField] private NetworkLatencyLogger latencyLogger;
 
-        private void OnEnable()
-        {
-            if (latencyLogger != null)
-            {
-                latencyLogger.OnPingUpdated += HandlePingUpdated;
-            }
-        }
-
-        private void OnDisable()
-        {
-            if (latencyLogger != null)
-            {
-                latencyLogger.OnPingUpdated -= HandlePingUpdated;
-            }
-        }
-
-        private void HandlePingUpdated(long rtt)
+        public void UpdatePing(long rtt)
         {
             if (pingText != null)
             {
@@ -38,4 +20,3 @@ namespace Game.Presentation
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- create Game.Presentation asmdef for camera and UI scripts
- expose ping display without infrastructure dependency
- reference Game.Presentation from infrastructure

## Testing
- `/opt/unity/Editor/Unity -projectPath CodexTest -runTests -batchmode -nographics -quit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ddcb9a82883218a4a5fd902ab54b0